### PR TITLE
Added material design dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.2.2",
     "@craco/craco": "^5.6.4",
+    "@material-ui/core": "^4.11.4",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@ant-design/icons": "^4.2.2",
     "@craco/craco": "^5.6.4",
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",


### PR DESCRIPTION
# Description
Currently, CodeLabZ has designed with Ant Design. Material UI Dependency added to replace the Ant Design 

### Issue
#72 Add dependencies for Material design

### Type of change 
- [x] New Dependency (non-breaking change which adds functionality)

## How Has This Been Tested?
- `npm start` without breaks

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes