### PR TITLE
Converted Login Screen from ant Design to Meterial UI Design

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "redux": "^4.0.5",
     "redux-auth-wrapper": "^3.0.0",
     "redux-firestore": "^0.13.0",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "validator": "^13.6.0"
   },
   "scripts": {
     "start": "craco start",

--- a/src/components/AuthPage/Login/index.js
+++ b/src/components/AuthPage/Login/index.js
@@ -65,12 +65,12 @@ const Login = () => {
   const validateEmail = () => {
     if (validator.isEmpty(email)) {
       setEmailValidateError(true);
-      setEmailValidateErrorMessage('Email is required!');
+      setEmailValidateErrorMessage('Please Enter your Email!');
       return false;
     }
     if (!validator.isEmail(email)) {
       setEmailValidateError(true);
-      setEmailValidateErrorMessage('Enter an valid email!');
+      setEmailValidateErrorMessage('Please enter an valid email!');
       return false;
     }
     return true;
@@ -79,7 +79,7 @@ const Login = () => {
   const validatePassword = () => {
     if (validator.isEmpty(password)) {
       setPasswordValidateError(true);
-      setPasswordValidateErrorMessage('Password is required!');
+      setPasswordValidateErrorMessage('Please enter your password!');
       return false;
     }
     return true;

--- a/src/components/AuthPage/Login/index.js
+++ b/src/components/AuthPage/Login/index.js
@@ -1,19 +1,15 @@
-import {
-  Checkbox,
-  FormControlLabel,
-  FormGroup,
-  Grid,
-  IconButton,
-  InputAdornment,
-  TextField,
-  Typography,
-} from '@material-ui/core';
-import {
-  LockOutlined,
-  MailOutlined,
-  Visibility,
-  VisibilityOff,
-} from '@material-ui/icons';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormGroup from '@material-ui/core/FormGroup';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import LockOutlined from '@material-ui/icons/LockOutlined';
+import MailOutlined from '@material-ui/icons/MailOutlined';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFirebase } from 'react-redux-firebase';

--- a/src/components/AuthPage/Login/index.js
+++ b/src/components/AuthPage/Login/index.js
@@ -1,28 +1,46 @@
-import React, { useEffect, useState } from "react";
-import { useFirebase } from "react-redux-firebase";
-import { Link } from "react-router-dom";
-import { clearAuthError, signIn } from "../../../store/actions";
 import {
-  Form,
-  Input,
-  Button,
-  Typography,
-  Row,
-  Col,
   Checkbox,
-  Divider,
-} from "antd";
-import { MailOutlined, LockOutlined } from "@ant-design/icons";
-import SmButtons from "../smButtons";
-import { useSelector, useDispatch } from "react-redux";
-import ViewAlerts from "./ViewAlerts";
-const { Title } = Typography;
+  FormControlLabel,
+  FormGroup,
+  Grid,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import {
+  LockOutlined,
+  MailOutlined,
+  Visibility,
+  VisibilityOff,
+} from '@material-ui/icons';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useFirebase } from 'react-redux-firebase';
+import { Link } from 'react-router-dom';
+import validator from 'validator';
+import Button from '../../../globalComponents/Button';
+import Divider from '../../../globalComponents/Divider';
+import { clearAuthError, signIn } from '../../../store/actions';
+import SmButtons from '../smButtons';
+import ViewAlerts from './ViewAlerts';
 
 const Login = () => {
   const firebase = useFirebase();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  const [email, setEmail] = useState("");
+  const [error, setError] = useState('');
+
+  const [email, setEmail] = useState('');
+  const [emailValidateError, setEmailValidateError] = useState(false);
+  const [emailValidateErrorMessage, setEmailValidateErrorMessage] =
+    useState('');
+
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [passwordValidateError, setPasswordValidateError] = useState(false);
+  const [passwordValidateErrorMessage, setPasswordValidateErrorMessage] =
+    useState('');
+
   const errorProp = useSelector(({ auth }) => auth.profile.error);
   const loadingProp = useSelector(({ auth }) => auth.profile.loading);
   const dispatch = useDispatch();
@@ -37,78 +55,158 @@ const Login = () => {
     [dispatch]
   );
 
-  const onSubmit = async (values) => {
-    setError("");
-    setEmail(values.email);
-    await signIn({ email: values.email, password: values.password })(
-      firebase,
-      dispatch
-    );
+  const handleClickShowPassword = () => setShowPassword(!showPassword);
+
+  const handleMouseDownPassword = (event) => event.preventDefault();
+
+  const onChangeEmail = (event) => setEmail(event.target.value);
+  const onChangePassword = (event) => setPassword(event.target.value);
+
+  const validateEmail = () => {
+    if (validator.isEmpty(email)) {
+      setEmailValidateError(true);
+      setEmailValidateErrorMessage('Email is required!');
+      return false;
+    }
+    if (!validator.isEmail(email)) {
+      setEmailValidateError(true);
+      setEmailValidateErrorMessage('Enter an valid email!');
+      return false;
+    }
+    return true;
+  };
+
+  const validatePassword = () => {
+    if (validator.isEmpty(password)) {
+      setPasswordValidateError(true);
+      setPasswordValidateErrorMessage('Password is required!');
+      return false;
+    }
+    return true;
+  };
+
+  const onSubmit = async () => {
+    if (validateEmail() & validatePassword()) {
+      setError('');
+      await signIn({ email: email, password: password })(firebase, dispatch);
+    }
+  };
+
+  const onFocusEmail = () => {
+    setEmailValidateError(false);
+    setEmailValidateErrorMessage('');
+  };
+
+  const onFocusPassword = () => {
+    setPasswordValidateError(false);
+    setPasswordValidateErrorMessage('');
   };
 
   return (
     <div className="pr-24 pl-24">
-      <Title level={2} style={{ textAlign: "center", marginBottom: "40px" }}>
+      <Typography
+        variant="h4"
+        style={{ textAlign: 'center', marginBottom: '40px' }}
+      >
         Welcome back!
-      </Title>
+      </Typography>
       <ViewAlerts error={error} email={email} />
-      <Form onFinish={onSubmit}>
-        <Form.Item
-          name={"email"}
-          rules={[
-            {
-              required: true,
-              message: "Please input your email address",
-            },
-            {
-              type: "email",
-              message: "Please enter a valid email address",
-            },
-          ]}
-        >
-          <Input
-            prefix={<MailOutlined style={{ color: "rgba(0,0,0,.25)" }} />}
-            placeholder="Email"
-            autoComplete="email"
-          />
-        </Form.Item>
-        <Form.Item
-          name={"password"}
-          rules={[{ required: true, message: "Please input your password" }]}
-        >
-          <Input.Password
-            prefix={<LockOutlined style={{ color: "rgba(0,0,0,.25)" }} />}
-            type="password"
-            placeholder="Password"
-            autoComplete="current-password"
-          />
-        </Form.Item>
-        <Form.Item>
-          <Form.Item name="remember" valuePropName="checked" noStyle>
-            <Checkbox>Remember me</Checkbox>
-          </Form.Item>
-          <Link
-            to="/forgotpassword"
-            className="login-form-forgot"
-            style={{ float: "right" }}
-          >
-            Forgot password
-          </Link>
-        </Form.Item>
-        <Form.Item>
-          <Button type="primary" htmlType="submit" block loading={loading}>
-            {loading ? "Logging in..." : "Log in"}
-          </Button>
-        </Form.Item>
-      </Form>
+      <div>
+        <TextField
+          error={emailValidateError}
+          label="Email"
+          variant="outlined"
+          placeholder="mail@codelabz.com"
+          value={email}
+          onChange={onChangeEmail}
+          helperText={emailValidateError ? emailValidateErrorMessage : null}
+          error={emailValidateError}
+          fullWidth
+          autoComplete="email"
+          required
+          onFocus={onFocusEmail}
+          style={{ marginBottom: '15px' }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <MailOutlined style={{ color: 'rgba(0,0,0,.25)' }} />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <TextField
+          label="Password"
+          variant="outlined"
+          helperText={
+            passwordValidateError ? passwordValidateErrorMessage : null
+          }
+          error={passwordValidateError}
+          fullWidth
+          required
+          value={password}
+          onFocus={onFocusPassword}
+          onChange={onChangePassword}
+          autoComplete="current-password"
+          type={showPassword ? 'text' : 'password'}
+          style={{ marginBottom: '15px' }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <LockOutlined style={{ color: 'rgba(0,0,0,.25)' }} />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={handleClickShowPassword}
+                  onMouseDown={handleMouseDownPassword}
+                >
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Grid container alignItems="center" justify="space-between">
+          <Grid>
+            <FormGroup row>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    // checked={state.checkedB}
+                    // onChange={handleChange}
+                    name="remember"
+                    color="primary"
+                  />
+                }
+                label="Remember me"
+              />
+            </FormGroup>
+          </Grid>
+          <Grid>
+            <Link
+              to="/forgotpassword"
+              className="login-form-forgot"
+              style={{ float: 'right' }}
+            >
+              Forgot password
+            </Link>
+          </Grid>
+        </Grid>
+
+        <Button type="primary" onClick={onSubmit}>
+          {loading ? 'Logging in...' : 'Log in'}
+        </Button>
+      </div>
       <Divider>or</Divider>
       <SmButtons />
-      <Row justify="center" align="center" className="mt-24">
-        <Col sm={24} className="center">
-          New to <span className="brand-font text-bold">CodeLabz</span>?{" "}
-          <Link to={"/signup"}>Create an account</Link>
-        </Col>
-      </Row>
+      <Grid container justify="center" alignItems="center" className="mt-24">
+        <Grid sm={12} className="center">
+          New to <span className="brand-font text-bold">CodeLabz</span>?{' '}
+          <Link to={'/signup'}>Create an account</Link>
+        </Grid>
+      </Grid>
     </div>
   );
 };

--- a/src/components/AuthPage/index.js
+++ b/src/components/AuthPage/index.js
@@ -1,20 +1,20 @@
-import React, { useState, useEffect } from "react";
-import { Row, Col } from "antd";
-import signinImage from "../../assets/images/signin-image.svg";
-import signupImage from "../../assets/images/signup-image.svg";
-import forgotPassImage from "../../assets/images/forgot-pass.svg";
-import Fade from "react-reveal/Fade";
-import Login from "./Login";
-import SignUp from "./SignUp";
-import { UserIsNotAuthenticated } from "../../auth";
-import ForgotPassword from "./ForgotPassword";
-import { useMediaQuery } from "react-responsive";
+import { Grid } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
+import Fade from 'react-reveal/Fade';
+import forgotPassImage from '../../assets/images/forgot-pass.svg';
+import signinImage from '../../assets/images/signin-image.svg';
+import signupImage from '../../assets/images/signup-image.svg';
+import { UserIsNotAuthenticated } from '../../auth';
+import ForgotPassword from './ForgotPassword';
+import Login from './Login';
+import SignUp from './SignUp';
 
 const AuthPage = ({ type }) => {
   const [show, setShow] = useState(false);
   const [showType, setShowType] = useState(type);
   const isDesktop = useMediaQuery({
-    query: "(min-device-width: 767px)",
+    query: '(min-device-width: 767px)',
   });
 
   useEffect(() => {
@@ -26,74 +26,66 @@ const AuthPage = ({ type }) => {
   }, [type]);
 
   return (
-    <Row
-      align="middle"
-      style={{ overflowX: "hidden" }}
+    <Grid
+      container
+      alignItems="center"
+      style={{ overflowX: 'hidden' }}
       justify="center"
       className="row-footer-below auth-margin"
+      direction={
+        showType === 'login' || showType === 'forgotpassword'
+          ? 'row'
+          : 'row-reverse'
+      }
     >
-      <Col
-        xs={0}
-        sm={0}
-        md={12}
-        lg={14}
-        order={showType === "login" || showType === "forgotpassword" ? 1 : 2}
-        className="auth-image-col"
-      >
+      <Grid xs={false} sm={false} md={6} lg={7} className="auth-image-col">
         <Fade
-          left={isDesktop ? showType === "login" : false}
+          left={isDesktop ? showType === 'login' : false}
           right={
             isDesktop
-              ? showType === "signup" || showType === "forgotpassword"
+              ? showType === 'signup' || showType === 'forgotpassword'
               : false
           }
           when={show}
         >
           <img
             src={
-              showType === "login"
+              showType === 'login'
                 ? signinImage
-                : showType === "signup"
+                : showType === 'signup'
                 ? signupImage
                 : forgotPassImage
             }
             alt="Background for auth"
             width="100%"
             className={
-              showType === "login" || showType === "forgotpassword"
-                ? "signin-image"
-                : "signup-image"
+              showType === 'login' || showType === 'forgotpassword'
+                ? 'signin-image'
+                : 'signup-image'
             }
           />
         </Fade>
-      </Col>
-      <Col
-        xs={24}
-        sm={24}
-        md={10}
-        lg={8}
-        order={showType === "login" || showType === "forgotpassword" ? 2 : 1}
-        className="auth-form-col"
-      >
+      </Grid>
+      <Grid xs={12} sm={12} md={5} lg={4} className="auth-form-col">
         <Fade
-          left={isDesktop ? showType === "login" : false}
+          left={isDesktop ? showType === 'login' : false}
           right={
             isDesktop
-              ? showType === "signup" || showType === "forgotpassword"
+              ? showType === 'signup' || showType === 'forgotpassword'
               : false
           }
           when={show}
         >
-          {showType === "login" ? (
+          {showType === 'login' ? (
             <Login />
-          ) : showType === "signup" ? (
+          ) : showType === 'signup' ? (
             <SignUp />
           ) : (
             <ForgotPassword />
           )}
         </Fade>
-      </Col>
-    </Row>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/src/components/AuthPage/index.js
+++ b/src/components/AuthPage/index.js
@@ -1,4 +1,4 @@
-import { Grid } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 import React, { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 import Fade from 'react-reveal/Fade';

--- a/src/globalComponents/Button.js
+++ b/src/globalComponents/Button.js
@@ -1,0 +1,27 @@
+import Button from '@material-ui/core/Button';
+import { withStyles } from '@material-ui/core/styles';
+
+const CodelabZButton = withStyles((theme) => ({
+  root: {
+    color: '#fff',
+    background: '#455A64',
+    borderColor: '#455A64',
+    width: '100%',
+    height: '32px',
+    padding: '4px 15px',
+    fontSize: '14px',
+    borderRadius: '5px',
+    textTransform: 'none',
+    fontWeight: '400',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    '&:hover': {
+      color: '#fff',
+      background: '#5f6b70',
+      borderColor: '#5f6b70',
+    },
+  },
+}))(Button);
+
+export default CodelabZButton;

--- a/src/globalComponents/Divider.js
+++ b/src/globalComponents/Divider.js
@@ -1,0 +1,34 @@
+import { makeStyles } from '@material-ui/core';
+import React from 'react';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  border: {
+    borderBottom: '1px solid lightgray',
+    width: '100%',
+  },
+  content: {
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    paddingRight: theme.spacing(2),
+    paddingLeft: theme.spacing(2),
+    fontSize: 16,
+    color: 'rgba(0, 0, 0, 0.85)',
+    fontWeight: 500,
+  },
+}));
+
+const Divider = ({ children }) => {
+  const classes = useStyles();
+  return (
+    <div className={classes.container}>
+      <div className={classes.border} />
+      <span className={classes.content}>{children}</span>
+      <div className={classes.border} />
+    </div>
+  );
+};
+export default Divider;


### PR DESCRIPTION
# Description
Currently, CodeLabZ Login has designed with Ant Design. Login Screen redesigned with material UI Components 

### Issue
#82  Convert Login Screen from ant Design to Material Design

### Type of change 
- [x] Change Design (non-breaking change which adds functionality)

## How Has This Been Tested?
- `npm start` without breaks
- Manual test login feature
- Manual test possible errors

## Screenshots

<table>
    <tr>
       <th>previous</th>
      <th>current</th>
   </tr>
<tr><td colspan="2">Login Screen without errors</td></tr>
   <tr>
     <td>
<img src="https://user-images.githubusercontent.com/27926576/119904805-94ddcd00-bf68-11eb-817f-3a7214704480.png"/>
</td> 
<td>
<img src="https://user-images.githubusercontent.com/27926576/119904835-9f986200-bf68-11eb-9818-222d251a5018.png"/>
</td>
  </tr>
<tr><td colspan="2">Login Screen with errors</td></tr>
   <tr>
     <td>
<img src="https://user-images.githubusercontent.com/27926576/119905052-133a6f00-bf69-11eb-8631-0648ad92537f.png"/>
</td> 
<td>
<img src="https://user-images.githubusercontent.com/27926576/119905071-22212180-bf69-11eb-966c-c7e360fe206c.png"/>
</td>
  </tr>
</table>

## Additional Components
- Material UI primary button styles matched with previous button styles - (`Button`)
- Divider created to same behavior like `ant` dIvider - (`Divider`)

### Note
TODO: Add loading behavior to Button

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes