### PR TITLE
Replace ant-design with material ui design in Footer

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -16,8 +16,26 @@ import {
   QuestionOutlined,
   CopyrightCircleOutlined,
 } from "@ant-design/icons";
+import { makeStyles } from "@material-ui/core/styles";
 import GitHubIcon from "@material-ui/icons/GitHub";
+import BugReportOutlinedIcon from "@material-ui/icons/BugReportOutlined";
+import ListOutlinedIcon from "@material-ui/icons/ListOutlined";
+import HelpOutlineOutlinedIcon from "@material-ui/icons/HelpOutlineOutlined";
+import CheckOutlinedIcon from "@material-ui/icons/CheckOutlined";
+import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
+import PhoneEnabledOutlinedIcon from "@material-ui/icons/PhoneEnabledOutlined";
+import MailOutlineOutlinedIcon from "@material-ui/icons/MailOutlineOutlined";
+import HomeOutlinedIcon from "@material-ui/icons/HomeOutlined";
+
 const Footer = () => {
+  const useStyles = makeStyles({
+    item: {
+      display: "flex",
+      alignItems: "left",
+      justifyContent: "flex-start",
+    },
+  });
+  const classes = useStyles();
   return (
     <footer className="light-grey-bg pt-16 pb-16">
       <Grid container direction="row">
@@ -39,7 +57,13 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <QuestionOutlined className="mr-8" /> About CodeLabz
+              <Grid className={classes.item}>
+                <HelpOutlineOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />{" "}
+                About CodeLabz
+              </Grid>
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -49,7 +73,13 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <CheckOutlined className="mr-8" /> Terms and conditions
+              <Grid className={classes.item}>
+                <CheckOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />{" "}
+                Terms and conditions
+              </Grid>
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -59,7 +89,13 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <LockOutlined className="mr-8" /> Privacy and security
+              <Grid className={classes.item}>
+                <LockOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />{" "}
+                Privacy and security
+              </Grid>
             </a>
           </div>
         </Grid>
@@ -71,9 +107,15 @@ const Footer = () => {
               href="https://github.com/scorelab/Codelabz"
               target="_blank"
               rel="noreferrer noopener"
-              className="mb-8 mt-8 footer-link"
+              className=" footer-link"
             >
-              <UnorderedListOutlined className="mr-8" /> FAQ
+              <Grid className={classes.item}>
+                <ListOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />
+                FAQ
+              </Grid>
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -83,7 +125,10 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <GitHubIcon className="mr-8" /> GitHub
+              <Grid className={classes.item}>
+                <GitHubIcon className="mr-8" style={{ color: "#455A64" }} />{" "}
+                GitHub
+              </Grid>
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -93,7 +138,13 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <BugOutlined className="mr-8" /> Report a bug
+              <Grid className={classes.item}>
+                <BugReportOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />{" "}
+                Report a bug
+              </Grid>
             </a>
           </div>
         </Grid>
@@ -102,7 +153,11 @@ const Footer = () => {
           <h3 className="mb-16">Contact</h3>
           <div className="mt-8 mb-8">
             <a href="tel: +94712345678" className="mb-8 mt-8 footer-link">
-              <PhoneOutlined className="mr-8" /> +94 712 345 678
+              <PhoneEnabledOutlinedIcon
+                className="mr-8"
+                style={{ color: "#455A64" }}
+              />{" "}
+              +94 712 345 678
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -110,7 +165,13 @@ const Footer = () => {
               href="mailto: contact@codelabz.com"
               className="mb-8 mt-8 footer-link"
             >
-              <MailOutlined className="mr-8" /> contact@codelabz.io
+              <Grid className={classes.item}>
+                <MailOutlineOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />{" "}
+                contact@codelabz.io
+              </Grid>
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -120,7 +181,13 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <HomeOutlined className="mr-8" /> 64, Singh Labs, Kings Canyon
+              <Grid className={classes.item}>
+                <HomeOutlinedIcon
+                  className="mr-8"
+                  style={{ color: "#455A64" }}
+                />{" "}
+                64, Singh Labs, Kings Canyon
+              </Grid>
             </a>
           </div>
         </Grid>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-// import { Row, Col, Divider } from "antd";
 import { Link } from "react-router-dom";
 import BrandName from "../../helpers/brandName";
 import Grid from "@material-ui/core/Grid";

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -2,6 +2,8 @@ import React from "react";
 import { Row, Col, Divider } from "antd";
 import { Link } from "react-router-dom";
 import BrandName from "../../helpers/brandName";
+import Grid from "@material-ui/core/Grid";
+// import Divider from '@material-ui/core/Divider';
 import {
   GithubOutlined,
   UnorderedListOutlined,
@@ -18,17 +20,17 @@ import {
 const Footer = () => {
   return (
     <footer className="light-grey-bg pt-16 pb-16">
-      <Row>
-        <Col sm={24} xs={24} md={6} className="col-pad-24">
+      <Grid container>
+        <Grid item sm={24} xs={24} md={6} className="col-pad-24">
           <h2 style={{ color: "#3AAFA9" }} className="brand-font mb-0">
             <Link to={"/"}>
               <BrandName />
             </Link>
           </h2>
           <p className="mb-">Live to learn, learn to live.</p>
-        </Col>
+        </Grid>
 
-        <Col xs={24} sm={24} md={6} className="col-pad-24">
+        <Grid item xs={24} sm={24} md={6} className="col-pad-24">
           <h3 className="mb-16">About</h3>
           <div className="mt-8 mb-8">
             <a
@@ -60,9 +62,9 @@ const Footer = () => {
               <LockOutlined className="mr-8" /> Privacy and security
             </a>
           </div>
-        </Col>
+        </Grid>
 
-        <Col xs={24} md={6} className="col-pad-24">
+        <Grid item xs={24} md={6} className="col-pad-24">
           <h3 className="mb-16">Help</h3>
           <div className="mt-8 mb-8">
             <a
@@ -94,9 +96,9 @@ const Footer = () => {
               <BugOutlined className="mr-8" /> Report a bug
             </a>
           </div>
-        </Col>
+        </Grid>
 
-        <Col xs={24} sm={24} md={6} className="col-pad-24">
+        <Grid item xs={24} sm={24} md={6} className="col-pad-24">
           <h3 className="mb-16">Contact</h3>
           <div className="mt-8 mb-8">
             <a href="tel: +94712345678" className="mb-8 mt-8 footer-link">
@@ -121,18 +123,18 @@ const Footer = () => {
               <HomeOutlined className="mr-8" /> 64, Singh Labs, Kings Canyon
             </a>
           </div>
-        </Col>
-      </Row>
+        </Grid>
+      </Grid>
 
-      <Row className="pr-24 pl-24">
+      <Grid container className="pr-24 pl-24">
         <Divider className="mt-0 mb-0" />
-      </Row>
+      </Grid>
 
-      <Row className="pt-16 pb-0">
-        <Col xs={24} className="center">
+      <Grid container className="pt-16 pb-0">
+        <Grid item xs={24} className="center">
           <CopyrightCircleOutlined /> {new Date().getFullYear()} CodeLabz
-        </Col>
-      </Row>
+        </Grid>
+      </Grid>
     </footer>
   );
 };

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { Row, Col, Divider } from "antd";
+// import { Row, Col, Divider } from "antd";
 import { Link } from "react-router-dom";
 import BrandName from "../../helpers/brandName";
 import Grid from "@material-ui/core/Grid";
-// import Divider from '@material-ui/core/Divider';
+import Divider from "@material-ui/core/Divider";
 import {
   GithubOutlined,
   UnorderedListOutlined,
@@ -16,12 +16,12 @@ import {
   QuestionOutlined,
   CopyrightCircleOutlined,
 } from "@ant-design/icons";
-
+import GitHubIcon from "@material-ui/icons/GitHub";
 const Footer = () => {
   return (
     <footer className="light-grey-bg pt-16 pb-16">
-      <Grid container>
-        <Grid item sm={24} xs={24} md={6} className="col-pad-24">
+      <Grid container direction="row">
+        <Grid item sm={24} xs={24} md={3} className="col-pad-24">
           <h2 style={{ color: "#3AAFA9" }} className="brand-font mb-0">
             <Link to={"/"}>
               <BrandName />
@@ -30,7 +30,7 @@ const Footer = () => {
           <p className="mb-">Live to learn, learn to live.</p>
         </Grid>
 
-        <Grid item xs={24} sm={24} md={6} className="col-pad-24">
+        <Grid item xs={24} sm={24} md={3} className="col-pad-24">
           <h3 className="mb-16">About</h3>
           <div className="mt-8 mb-8">
             <a
@@ -64,7 +64,7 @@ const Footer = () => {
           </div>
         </Grid>
 
-        <Grid item xs={24} md={6} className="col-pad-24">
+        <Grid item xs={12} sm={24} md={3} className="col-pad-24">
           <h3 className="mb-16">Help</h3>
           <div className="mt-8 mb-8">
             <a
@@ -83,7 +83,7 @@ const Footer = () => {
               rel="noreferrer noopener"
               className="mb-8 mt-8 footer-link"
             >
-              <GithubOutlined className="mr-8" /> GitHub
+              <GitHubIcon className="mr-8" /> GitHub
             </a>
           </div>
           <div className="mt-8 mb-8">
@@ -98,7 +98,7 @@ const Footer = () => {
           </div>
         </Grid>
 
-        <Grid item xs={24} sm={24} md={6} className="col-pad-24">
+        <Grid item xs={24} sm={24} md={3} className="col-pad-24">
           <h3 className="mb-16">Contact</h3>
           <div className="mt-8 mb-8">
             <a href="tel: +94712345678" className="mb-8 mt-8 footer-link">
@@ -126,12 +126,9 @@ const Footer = () => {
         </Grid>
       </Grid>
 
-      <Grid container className="pr-24 pl-24">
-        <Divider className="mt-0 mb-0" />
-      </Grid>
-
+      <Divider />
       <Grid container className="pt-16 pb-0">
-        <Grid item xs={24} className="center">
+        <Grid item xs={12} className="center">
           <CopyrightCircleOutlined /> {new Date().getFullYear()} CodeLabz
         </Grid>
       </Grid>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -4,18 +4,6 @@ import { Link } from "react-router-dom";
 import BrandName from "../../helpers/brandName";
 import Grid from "@material-ui/core/Grid";
 import Divider from "@material-ui/core/Divider";
-import {
-  GithubOutlined,
-  UnorderedListOutlined,
-  BugOutlined,
-  PhoneOutlined,
-  MailOutlined,
-  HomeOutlined,
-  CheckOutlined,
-  LockOutlined,
-  QuestionOutlined,
-  CopyrightCircleOutlined,
-} from "@ant-design/icons";
 import { makeStyles } from "@material-ui/core/styles";
 import GitHubIcon from "@material-ui/icons/GitHub";
 import BugReportOutlinedIcon from "@material-ui/icons/BugReportOutlined";

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -14,6 +14,7 @@ import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
 import PhoneEnabledOutlinedIcon from "@material-ui/icons/PhoneEnabledOutlined";
 import MailOutlineOutlinedIcon from "@material-ui/icons/MailOutlineOutlined";
 import HomeOutlinedIcon from "@material-ui/icons/HomeOutlined";
+import CopyrightOutlinedIcon from "@material-ui/icons/CopyrightOutlined";
 
 const Footer = () => {
   const useStyles = makeStyles({
@@ -183,8 +184,18 @@ const Footer = () => {
 
       <Divider />
       <Grid container className="pt-16 pb-0">
-        <Grid item xs={12} className="center">
-          <CopyrightCircleOutlined /> {new Date().getFullYear()} CodeLabz
+        <Grid
+          item
+          xs={12}
+          className="center"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            textAlign: "center",
+            justifyContent: "center",
+          }}
+        >
+          <CopyrightOutlinedIcon /> {new Date().getFullYear()} CodeLabz
         </Grid>
       </Grid>
     </footer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
replaced all ant design code and replaced with material ui 
## Description
Fixed #92 

## Screenshots (In case of UI changes):
# Desktop View ->
![Screenshot from 2021-06-03 00-34-16](https://user-images.githubusercontent.com/52108435/120538180-d1e00e80-c403-11eb-843a-561bf172dd6f.png)
# Mobile View ->
![Screenshot from 2021-06-03 00-34-07](https://user-images.githubusercontent.com/52108435/120538200-d86e8600-c403-11eb-8069-730acf8ab18b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] UI Change
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
