### PR TITLE
Convert Myfeed to Material Ui

### DIFF
--- a/src/components/MyFeed/ExploreOrgs.js
+++ b/src/components/MyFeed/ExploreOrgs.js
@@ -1,14 +1,40 @@
-import { Button, Card, Col, Row } from 'antd';
-import Meta from 'antd/lib/card/Meta';
-import Paragraph from 'antd/lib/typography/Paragraph';
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { useFirestore } from 'react-redux-firebase';
-import { Link } from 'react-router-dom';
-import BrandName from '../../helpers/brandName';
-import { clearOrgData, getLaunchedOrgsData } from '../../store/actions';
+import React, { useEffect } from "react";
+import Box from "@material-ui/core/Box";
+import Grid from "@material-ui/core/Grid";
+import noimage from "../../assets/images/no-image-available.svg";
+import Skeleton from "@material-ui/lab/Skeleton";
+import Card from "@material-ui/core/Card";
+import CardActionArea from "@material-ui/core/CardActionArea";
+import CardContent from "@material-ui/core/CardContent";
+import CardMedia from "@material-ui/core/CardMedia";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+import { makeStyles } from "@material-ui/core/styles";
+import { useDispatch, useSelector } from "react-redux";
+import { useFirestore } from "react-redux-firebase";
+import { Link } from "react-router-dom";
+import BrandName from "../../helpers/brandName";
+import { clearOrgData, getLaunchedOrgsData } from "../../store/actions";
+import { CardHeader } from "@material-ui/core";
+
+const useStyles = makeStyles({
+  root: {
+    paddingBottom: 10,
+  },
+
+  card: {
+    height: 450,
+    maxWidth: 345,
+  },
+
+  media: {
+    height: 320,
+    margin: "auto",
+  },
+});
 
 const ExploreOrgs = () => {
+  const classes = useStyles();
   const loading = useSelector(({ org }) => org.launched.loading);
   const error = useSelector(({ org }) => org.launched.error);
   const launchedOrgs = useSelector(({ org }) => org.launched.data);
@@ -23,51 +49,83 @@ const ExploreOrgs = () => {
   }, [firestore, dispatch]);
 
   return (
-    <Row justify="center" gutter={[16, 16]}>
-      {launchedOrgs &&
-        launchedOrgs
-          .map((a) => ({ sort: Math.random(), value: a }))
-          .sort((a, b) => a.sort - b.sort)
-          .map((a) => a.value)
-          .slice(0, 5)
-          .map((org) => (
-            <Col xs={24} sm={12} md={8} lg={4} key={org.org_handle}>
-              <Link to={`/org/${org.org_handle}`}>
-                <Card
-                  style={{ height: '100%' }}
-                  hoverable
-                  cover={
-                    <img src={org.org_image} alt={org.org_handle} width={250} />
-                  }
-                >
-                  <Meta
-                    title={org.org_name}
-                    description={
-                      <Paragraph ellipsis={{ rows: 2 }}>
-                        {org.org_description}
-                      </Paragraph>
-                    }
-                  />
+    <Box m={5}>
+      {loading ? (
+        <div>
+          <Skeleton variant="rect" width={210} height={118} />
+          <Skeleton variant="rect" width={210} height={118} />
+        </div>
+      ) : (
+        <Grid container spacing={2} align="center">
+          {error ? (
+            <Typography variant="body1" color="textSecondary">
+              {error}
+            </Typography>
+          ) : (
+            <>
+              {launchedOrgs &&
+                launchedOrgs
+                  .map((a) => ({ sort: Math.random(), value: a }))
+                  .sort((a, b) => a.sort - b.sort)
+                  .map((a) => a.value)
+                  .slice(0, 5)
+                  .map((org) => (
+                    <Grid item xs={12} md={6} lg={3} className={classes.root}>
+                      <Link to={`/org/${org.org_handle}`}>
+                        <Card className={classes.card}>
+                          <CardActionArea>
+                            <CardMedia
+                              className={classes.media}
+                              image={org.org_image ? org.org_image : noimage}
+                              title={org.org_name}
+                            />
+                            <CardContent>
+                              <Typography
+                                gutterBottom
+                                variant="h5"
+                                component="h2"
+                              >
+                                {org.org_name}
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                color="textSecondary"
+                                component="p"
+                                noWrap={true}
+                              >
+                                {org.org_description}
+                              </Typography>
+                            </CardContent>
+                          </CardActionArea>
+                        </Card>
+                      </Link>
+                    </Grid>
+                  ))}
+              <Grid item xs={12} md={6} lg={3} className={classes.root}>
+                <Card>
+                  <CardHeader title="Didn't find Any?" />
+                  <CardContent>
+                    <Typography variant="body1" color="textSecondary">
+                      Don't worry there are many organization with
+                      <h1>
+                        <BrandName />
+                      </h1>
+                    </Typography>
+                    <Button
+                      style={{ backgroundColor: "#0f7029", color: "white" }}
+                      fullWidth
+                      variant="contained"
+                    >
+                      Explore More
+                    </Button>
+                  </CardContent>
                 </Card>
-              </Link>
-            </Col>
-          ))}
-      <Col xs={24} sm={12} md={8} lg={4}>
-        <Card
-          hoverable
-          style={{ height: '100%' }}
-          title="Didn't find?"
-          extra={<Button>Explore</Button>}
-        >
-          <p style={{ height: '100%' }}>
-            don't worry there are many organization with
-          </p>
-          <h1>
-            <BrandName />
-          </h1>
-        </Card>
-      </Col>
-    </Row>
+              </Grid>
+            </>
+          )}
+        </Grid>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/MyFeed/ExploreOrgs.js
+++ b/src/components/MyFeed/ExploreOrgs.js
@@ -70,7 +70,7 @@ const ExploreOrgs = () => {
                   .map((a) => a.value)
                   .slice(0, 5)
                   .map((org) => (
-                    <Grid item xs={12} md={6} lg={3} className={classes.root}>
+                    <Grid item xs={12} md={6} lg={3} className={classes.root} key={org.org_handle}> 
                       <Link to={`/org/${org.org_handle}`}>
                         <Card className={classes.card}>
                           <CardActionArea>

--- a/src/components/MyFeed/index.js
+++ b/src/components/MyFeed/index.js
@@ -10,11 +10,13 @@ const MyFeed = () => {
       <Grid container>
         <Grid
           container
+          item
+          xs={12}
           spacing={0}
           direction="column"
           alignItems="center"
           justify="center"
-          style={{ paddingTop: "15px" }}
+          style={{ padding: "15px" }}
         >
           <Typography variant="h2">Explore Codelabz</Typography>
           <p>
@@ -23,7 +25,7 @@ const MyFeed = () => {
           </p>
         </Grid>
 
-        <Grid>
+        <Grid item xs={12}>
           {" "}
           <ExploreOrgs />
         </Grid>

--- a/src/components/MyFeed/index.js
+++ b/src/components/MyFeed/index.js
@@ -1,37 +1,34 @@
-import { Card, Col, Row } from 'antd';
-import React from 'react';
-import BrandName from '../../helpers/brandName';
-import ExploreOrgs from './ExploreOrgs';
+import Grid from "@material-ui/core/Grid";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+import React from "react";
+import ExploreOrgs from "./ExploreOrgs";
 
 const MyFeed = () => {
   return (
-    <Card bordered={false}>
-      <Row justify="center">
-        <Col xs={24} md={8} />
-        <Col xs={24} md={8}>
-          <h2 style={{ textAlign: 'center' }}>
-            <BrandName /> My Feed
-          </h2>
-        </Col>
-        <Col xs={24} md={8} />
-      </Row>
-      <Col>
-        <h2>Explore Organizations</h2>
-        <p>
-          Explore top rated Organizations and find the <b>Codelabz</b> you are
-          looking for;
-        </p>
-      </Col>
-      <ExploreOrgs />
-      {/* <Divider />
-      <Col>
-        <h2>Explore Codelabz</h2>
-        <p>
-          Explore top rated User created <b>Codelabz</b> and find what you are
-          looking for;
-        </p>
-      </Col> */}
-    </Card>
+    <Box>
+      <Grid container>
+        <Grid
+          container
+          spacing={0}
+          direction="column"
+          alignItems="center"
+          justify="center"
+          style={{ paddingTop: "15px" }}
+        >
+          <Typography variant="h2">Explore Codelabz</Typography>
+          <p>
+            Explore top rated Organizations and find the <b>Codelabz</b> you are
+            looking for
+          </p>
+        </Grid>
+
+        <Grid>
+          {" "}
+          <ExploreOrgs />
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Converted the Myfeed to  materil ui. Component is no longer depend on antd. Checked with all the existing functionality.

## Related Issue
Fix #114 


## How Has This Been Tested?
Everything is working as before

## Screenshots or GIF (In case of UI changes):
**Click on image to see a enlarge version** 
**Antd - Previous** 
<img src="https://user-images.githubusercontent.com/31257148/122483680-c2aab480-cff0-11eb-8544-eeb4c1d9709c.PNG " width="350">
**Material ui -Current** 
<img src="https://user-images.githubusercontent.com/31257148/122483582-8b3c0800-cff0-11eb-84e7-d4c1be652ef1.png " width="350">
<img src="https://user-images.githubusercontent.com/31257148/122484206-c68b0680-cff1-11eb-9361-5064cebcae75.png " height="350">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
