### PR TITLE
Fix missing default values in Organization edit modal

### DIFF
--- a/src/components/Organization/OrgInfoCard/editOrgDetailsModal.js
+++ b/src/components/Organization/OrgInfoCard/editOrgDetailsModal.js
@@ -67,14 +67,14 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
   }, [closeModal, loading, error]);
 
   const [formValue, setformValue] = useState({
-    org_name: "",
-    org_website: "",
-    org_link_facebook: "",
-    org_link_github: "",
-    org_link_linkedin: "",
-    org_link_twitter: "",
-    org_description: "",
-    org_country: "",
+    org_name: currentOrgData.org_name,
+    org_website: currentOrgData.org_website,
+    org_link_facebook: currentOrgData.org_link_facebook,
+    org_link_github: currentOrgData.org_link_github,
+    org_link_linkedin: currentOrgData.org_link_linkedin,
+    org_link_twitter: currentOrgData.org_link_twitter,
+    org_description: currentOrgData.org_description,
+    org_country: currentOrgData.org_country,
   });
 
   const onSubmit = (formData) => {
@@ -107,6 +107,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           fullWidth
           style={{ marginBottom: "1.5rem" }}
           name="org_name"
+          defaultValue={formValue.org_name}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -127,6 +128,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           autoComplete="url"
           fullWidth
           name="org_website"
+          defaultValue={formValue.org_website}
           style={{ marginBottom: "1.5rem" }}
           InputProps={{
             startAdornment: (
@@ -145,6 +147,9 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           placeholder="Provide a description about the organization and/or the tutorials published"
           fullWidth
           name="org_description"
+          defaultValue={formValue.org_description}
+          multiline
+          rows={4}
           style={{ marginBottom: "1.5rem" }}
           onChange={(e) => handleChange(e)}
         ></TextField>
@@ -155,6 +160,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           placeholder="Facebook page handle"
           autoComplete="none"
           fullWidth
+          defaultValue={formValue.org_link_facebook}
           style={{ marginBottom: "1.5rem" }}
           name="org_link_facebook"
           InputProps={{
@@ -176,6 +182,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           fullWidth
           style={{ marginBottom: "1.5rem" }}
           name="org_link_twitter"
+          defaultValue={formValue.org_link_twitter}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -196,6 +203,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           fullWidth
           style={{ marginBottom: "1.5rem" }}
           name="org_link_linkedin"
+          defaultValue={formValue.org_link_linkedin}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -217,6 +225,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
           fullWidth
           style={{ marginBottom: "2.5rem" }}
           name="org_link_github"
+          defaultValue={formValue.org_link_github}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When we try to edit organization details ,organization edit modal wont shows the existing details of that organization. Add default value options to the text fields.

## Related Issue
Fix #116 



## Screenshots or GIF (In case of UI changes):
![5665](https://user-images.githubusercontent.com/31257148/122485791-60a07e00-cff5-11eb-8058-29a3b201b49b.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
