### PR TITLE
Fix gap between icons and text in profile view 

### DIFF
--- a/src/components/Profile/ViewProfile/index.js
+++ b/src/components/Profile/ViewProfile/index.js
@@ -139,6 +139,7 @@ const ProfileView = () => {
                         <div
                           style={{
                             display: "flex",
+                            gap: "10px",
                           }}
                         >
                           <FacebookIcon
@@ -160,6 +161,7 @@ const ProfileView = () => {
                         <div
                           style={{
                             display: "flex",
+                            gap: "10px",
                           }}
                         >
                           <TwitterIcon
@@ -181,6 +183,7 @@ const ProfileView = () => {
                         <div
                           style={{
                             display: "flex",
+                            gap: "10px",
                           }}
                         >
                           <GitHubIcon
@@ -205,6 +208,7 @@ const ProfileView = () => {
                         <div
                           style={{
                             display: "flex",
+                            gap: "10px",
                           }}
                         >
                           <LinkedInIcon
@@ -226,6 +230,7 @@ const ProfileView = () => {
                         <div
                           style={{
                             display: "flex",
+                            gap: "10px",
                           }}
                         >
                           <LinkIcon
@@ -250,6 +255,7 @@ const ProfileView = () => {
                         <div
                           style={{
                             display: "flex",
+                            gap: "10px",
                           }}
                         >
                           <FlagIcon


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was no visible gape icons and text in profile view . Add some padding 

## Related Issue
Fix #120 

## Screenshots or GIF (In case of UI changes):
![33](https://user-images.githubusercontent.com/31257148/122490293-4ec3d880-cfff-11eb-8695-81d6dd5cfc76.PNG)
![42](https://user-images.githubusercontent.com/31257148/122490297-52eff600-cfff-11eb-86b0-dd00581f5473.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
