### PR TITLE
Rearranged Org logo position

### DIFF
--- a/src/components/util/CodelabCard/index.js
+++ b/src/components/util/CodelabCard/index.js
@@ -39,22 +39,7 @@ const CardComponent = ({
               justify="center"
               alignItems="center"
             >
-              {logoPath ? (
-                <Grid container>
-                  <Grid item className={classes.headerGrid}>
-                    <img src="/logo.jpeg" alt="logo" className={classes.logoImg} />
-                    <img
-                      src={require(`../../../assets/images/${profilePic}`).default}
-                      alt=""
-                      height="20rem"
-                      width="20rem"
-                      className={classes.personImg}
-                    />
-                  </Grid>
-                </Grid>
-              ) : (
                 <img src={require(`../../../assets/images/${profilePic}`).default} alt="" className={classes.avatar} />
-              )}
             </Grid>
           }
           title={
@@ -65,6 +50,17 @@ const CardComponent = ({
             ) : (
               <Typography variant="body">Demo Name</Typography>
             )
+          }
+          action={
+              logoPath ? (
+                <IconButton aria-label="settings">
+                   <img src="/logo.jpeg" alt="logo" className={classes.logoImg} />
+                  </IconButton>
+              ) : (
+                <IconButton aria-label="settings"> 
+                </IconButton>
+              )
+            
           }
           subheader="May25,2021(3 days ago)"
           titleTypographyProps={{ align: "left" }}

--- a/src/components/util/CodelabCard/styles.js
+++ b/src/components/util/CodelabCard/styles.js
@@ -100,7 +100,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: "500px",
   },
   logoImg: {
-    height: "1rem",
+    height: "2rem",
   },
 }));
 


### PR DESCRIPTION
## Description
When the post is from registered org, we try to fit log and avatar both in the same place. That make the avatar inconsistent and small from the normal avatar.

## Related Issue
This PR Fixes #221 

## Motivation and Context
Avatar size should be consistent

## Screenshots or GIF (In case of UI changes):
![WhatsApp Image 2022-02-16 at 12 09 54 PM](https://user-images.githubusercontent.com/55620053/154210119-3b220d58-86c6-46fd-b3eb-4cb04b87b234.jpeg)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
