### PR TITLE
added path for making new codelab from appbar

### DIFF
--- a/src/helpers/appBar.js
+++ b/src/helpers/appBar.js
@@ -33,13 +33,13 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   newButtonMobile: {
-    [theme.breakpoints.up("sm")]: {
+    [theme.breakpoints.up("md")]: {
       display: "none",
     },
   },
   title: {
     display: "none",
-    [theme.breakpoints.up("sm")]: {
+    [theme.breakpoints.up("md")]: {
       display: "block",
     },
   },
@@ -181,14 +181,16 @@ const CodeLabzAppBar = () => {
             <div className={classes.grow} />
 
             <div className={classes.newButtonDesktop}>
-              <Button
-                variant="contained"
-                color="primary"
-                style={{ backgroundColor: "royalblue" }}
-                endIcon={<AddIcon />}
-              >
-                New Codelab
-              </Button>
+              <NavLink to="/tutorials">
+                <Button
+                  variant="contained"
+                  color="primary"
+                  style={{ backgroundColor: "royalblue" }}
+                  endIcon={<AddIcon />}
+                >
+                  New Codelab
+                </Button>
+              </NavLink>
             </div>
 
             <div className={classes.newButtonMobile}>
@@ -250,14 +252,16 @@ const CodeLabzAppBar = () => {
             </div>
             <div className={classes.grow} />
             <div className={classes.newButtonDesktop}>
-              <Button
-                variant="contained"
-                color="primary"
-                style={{ backgroundColor: "royalblue" }}
-                endIcon={<AddIcon />}
-              >
-                New Codelab
-              </Button>
+              <NavLink to="/tutorials">
+                <Button
+                  variant="contained"
+                  color="primary"
+                  style={{ backgroundColor: "royalblue" }}
+                  endIcon={<AddIcon />}
+                >
+                  New Codelab
+                </Button>
+              </NavLink>
             </div>
             <div className={classes.newButtonMobile}>
               <IconButton>


### PR DESCRIPTION
Added path of tutorials for making new codelab through appbar.

## Description
The New Codelab button on the appbar was not working. So I found out that there is a dedicated page for publishing new codelab but no one could access it from appbar. 

## Related Issue
#211 

## Motivation and Context
Users should be able to access the new codelab feature and the button should not be idle.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
