### PR TITLE
remove social media required inputs

### DIFF
--- a/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
+++ b/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
@@ -191,6 +191,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           helperText={nameValidateError ? nameValidateErrorMessage : null}
           fullWidth
           autoComplete="handle"
+          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -203,7 +204,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
       </Box>
 
       <Box m={2}>
-        <FormControl variant="outlined" error={countryValidateError} fullWidth>
+        <FormControl required variant="outlined" error={countryValidateError} fullWidth>
           <InputLabel>Country</InputLabel>
           <Select
             label="Country"
@@ -226,6 +227,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           onChange={(event) => onChangeOrgWebsite(event.target.value)}
           helperText={websiteValidateError ? websiteValidateErrorMessage : null}
           fullWidth
+          required
           autoComplete="orgWebsite"
           style={{ marginBottom: "15px" }}
           InputProps={{
@@ -245,6 +247,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           multiline
           variant="outlined"
           placeholder="Description"
+          required
           data-testId="editProfileDescription"
           value={description}
           onChange={(event) => onChangeDescription(event.target.value)}

--- a/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
+++ b/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
@@ -62,28 +62,9 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
     setDescriptionValidateErrorMessage,
   ] = useState("");
   const [facebook, setFacebook] = useState(getData(profileData.link_facebook));
-  const [facebookValidateError, setFacebookValidateError] = useState(false);
-  const [
-    facebookValidateErrorMessage,
-    setFacebookValidateErrorMessage,
-  ] = useState("");
   const [twitter, setTwitter] = useState(getData(profileData.link_twitter));
-  const [twitterValidateError, setTwitterValidateError] = useState(false);
-  const [
-    twitterValidateErrorMessage,
-    setTwitterValidateErrorMessage,
-  ] = useState("");
   const [linkedin, setLinkedin] = useState(getData(profileData.link_linkedin));
-  const [linkedinValidateError, setLinkedinValidateError] = useState(false);
-  const [
-    linkedinValidateErrorMessage,
-    setLinkedinValidateErrorMessage,
-  ] = useState("");
   const [github, setGithub] = useState(getData(profileData.link_github));
-  const [githubValidateError, setGithubValidateError] = useState(false);
-  const [githubValidateErrorMessage, setGithubValidateErrorMessage] = useState(
-    ""
-  );
 
   const children = [];
   for (let i = 0; i < countryList.length; i++) {
@@ -148,39 +129,11 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
       setDescriptionValidateErrorMessage,
       "Please enter a description"
     );
-    const facebookValid = validateIsEmpty(
-      facebook,
-      setFacebookValidateError,
-      setFacebookValidateErrorMessage,
-      "Please enter a Facebook username"
-    );
-    const twitterValid = validateIsEmpty(
-      twitter,
-      setTwitterValidateError,
-      setTwitterValidateErrorMessage,
-      "Please enter a Twitter username"
-    );
-    const linkedinValid = validateIsEmpty(
-      linkedin,
-      setLinkedinValidateError,
-      setLinkedinValidateErrorMessage,
-      "Please enter a LinkedIn username"
-    );
-    const githubValid = validateIsEmpty(
-      github,
-      setGithubValidateError,
-      setGithubValidateErrorMessage,
-      "Please enter a GitHub username"
-    );
     if (
       nameValid &&
       countryValid &&
       orgWebsiteValid &&
-      descriptionValid &&
-      facebookValid &&
-      twitterValid &&
-      githubValid &&
-      linkedinValid
+      descriptionValid
     ) {
       return true;
     } else {
@@ -238,7 +191,6 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           helperText={nameValidateError ? nameValidateErrorMessage : null}
           fullWidth
           autoComplete="handle"
-          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -275,7 +227,6 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           helperText={websiteValidateError ? websiteValidateErrorMessage : null}
           fullWidth
           autoComplete="orgWebsite"
-          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -302,7 +253,6 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           }
           fullWidth
           autoComplete="description"
-          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -316,19 +266,14 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
 
       <Box m={2}>
         <TextField
-          error={facebookValidateError}
           label="Facebook"
           variant="outlined"
           placeholder="username"
           value={facebook}
           data-testId="editProfileFacebook"
           onChange={(event) => onChangeFacebook(event.target.value)}
-          helperText={
-            facebookValidateError ? facebookValidateErrorMessage : null
-          }
           fullWidth
           autoComplete="handle"
-          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -345,17 +290,14 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
 
       <Box m={2}>
         <TextField
-          error={twitterValidateError}
           label="Twitter"
           variant="outlined"
           value={twitter}
           placeholder="username"
           data-testId="editProfileTwitter"
           onChange={(event) => onChangeTwitter(event.target.value)}
-          helperText={twitterValidateError ? twitterValidateErrorMessage : null}
           fullWidth
           autoComplete="handle"
-          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -372,19 +314,15 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
 
       <Box m={2}>
         <TextField
-          error={linkedinValidateError}
           label="LinkedIn"
           variant="outlined"
           value={linkedin}
           data-testId="editProfileLinkedin"
           placeholder="username"
           onChange={(event) => onChangeLinkedin(event.target.value)}
-          helperText={
-            linkedinValidateError ? linkedinValidateErrorMessage : null
-          }
           fullWidth
           autoComplete="handle"
-          required
+           
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (
@@ -401,17 +339,14 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
 
       <Box m={2}>
         <TextField
-          error={githubValidateError}
           label="GitHub"
           variant="outlined"
           value={github}
           placeholder="username"
           onChange={(event) => onChangeGithub(event.target.value)}
-          helperText={githubValidateError ? githubValidateErrorMessage : null}
           fullWidth
           data-testId="editProfileGithub"
           autoComplete="handle"
-          required
           style={{ marginBottom: "15px" }}
           InputProps={{
             startAdornment: (


### PR DESCRIPTION
## Description
- Removed required fields from social media inputs.
- Ensured that empty fields on submission do not give validation error.

## Related Issue
#254 

## Motivation and Context
Sometime a user might not have an account on a social media platform or may not want to provide the link to it. 
Required addition can be annoying if user does not wish to add a specific information.

## How Has This Been Tested?
Tried editing user profile without adding specific links and made sure that empty content is not visible on the profile page and that no validation errors creep in.

## Screenshots or GIF (In case of UI changes):
<img width="838" alt="Screenshot 2022-04-11 at 02 21 32" src="https://user-images.githubusercontent.com/77532581/162639288-289866e5-988d-48d8-810a-4b61880e171c.png">


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
