### PR TITLE
removed material ui prop console errors

### DIFF
--- a/src/components/AuthPage/ForgotPassword/index.js
+++ b/src/components/AuthPage/ForgotPassword/index.js
@@ -70,7 +70,7 @@ const ForgotPassword = ({
   const classes = useStyles();
 
   return (
-    <Card className={classes.root} data-testId="forgotPassword">
+    <Card className={classes.root} data-testid="forgotPassword">
       <Typography
         variant="h4"
         className={"mb-24 text-center " + classes.heading}
@@ -121,7 +121,7 @@ const ForgotPassword = ({
           className="mb-32"
           fullWidth
           height="10rem"
-          data-testId="forgotPasswordEmail"
+          data-testid="forgotPasswordEmail"
           startAdornment={
             <InputAdornment sposition="start">
               <MailOutlineOutlinedIcon style={{ color: "rgba(0,0,0,.25)" }} />
@@ -137,7 +137,7 @@ const ForgotPassword = ({
           className="mt-10"
           type="submit"
           fullWidth
-          data-testId="forgotPasswordButton"
+          data-testid="forgotPasswordButton"
         >
           {loading ? "Sending..." : "Send me the link"}
         </Button>

--- a/src/components/AuthPage/ForgotPassword/index.js
+++ b/src/components/AuthPage/ForgotPassword/index.js
@@ -142,15 +142,15 @@ const ForgotPassword = ({
           {loading ? "Sending..." : "Send me the link"}
         </Button>
       </form>
-      <Grid justify="center" align="center" className="mt-16">
+      <Grid justifyContent="center" align="center" className="mt-16">
         or
       </Grid>
-      <Grid justify="center" align="center" className="mt-24">
+      <Grid justifyContent="center" align="center" className="mt-24">
         <Grid sm={24} className="center">
           <Link to={"/login"}>Back to Sign in</Link>
         </Grid>
       </Grid>
-      <Grid justify="center" align="center" className="mt-24">
+      <Grid justifyContent="center" align="center" className="mt-24">
         <Grid sm={24} className="center">
           New to <span className="brand-font text-bold">CodeLabz</span>?{" "}
           <Link to={"/signup"}>Create an account</Link>

--- a/src/components/AuthPage/Login/index.js
+++ b/src/components/AuthPage/Login/index.js
@@ -101,7 +101,7 @@ const Login = ({ loginButton = "blue", background = "white", loginText = "Welcom
   };
 
   return (
-    <Card raised className={`${classes.card}   `} style={{ background: background }} data-testId="login">
+    <Card raised className={`${classes.card}   `} style={{ background: background }} data-testid="login">
       <CardContent>
         <Typography variant="h4" style={{ textAlign: "center", marginBottom: "40px" }}>
           {loginText}
@@ -171,7 +171,7 @@ const Login = ({ loginButton = "blue", background = "white", loginText = "Welcom
             </Grid>
             <Grid>
               <Link
-                data-testId="forgotPassoword"
+                data-testid="forgotPassoword"
                 to="/forgotpassword"
                 className="login-form-forgot"
                 style={{ float: "right" }}

--- a/src/components/AuthPage/Login/index.js
+++ b/src/components/AuthPage/Login/index.js
@@ -163,7 +163,7 @@ const Login = ({ loginButton = "blue", background = "white", loginText = "Welcom
               ),
             }}
           />
-          <Grid container alignItems="center" justify="space-between">
+          <Grid container alignItems="center" justifyContent="space-between">
             <Grid>
               <FormGroup row>
                 <FormControlLabel control={<Checkbox name="remember" color="primary" />} label="Remember me" />
@@ -195,7 +195,7 @@ const Login = ({ loginButton = "blue", background = "white", loginText = "Welcom
         </div>
         <Divider>or</Divider>
         <SmButtons />
-        <Grid container justify="center" alignItems="center" className="mt-24">
+        <Grid container justifyContent="center" alignItems="center" className="mt-24">
           <Grid item={true} sm={12} className="center">
             New to <span className="brand-font text-bold">CodeLabz</span>? <Link to={"/signup"}>Create an account</Link>
           </Grid>

--- a/src/components/AuthPage/SignUp/index.js
+++ b/src/components/AuthPage/SignUp/index.js
@@ -13,7 +13,7 @@ import PropTypes from "prop-types";
 const SignUp = ({ background = "white" }) => {
   const classes = useStyles();
   return (
-    <Card raised className={`${classes.card}   `} data-testId="signUp" style={{ background: background }}>
+    <Card raised className={`${classes.card}   `} data-testid="signUp" style={{ background: background }}>
     
       <CardContent>
         <Typography
@@ -30,7 +30,7 @@ const SignUp = ({ background = "white" }) => {
           justifyContent="center"
           alignItems="center"
           className="mt-24"
-          data-testId="signUpHaveAccount"
+          data-testid="signUpHaveAccount"
         >
           <Grid item={true} sm={12} className="center">
             Already have a{" "}

--- a/src/components/AuthPage/SignUp/index.js
+++ b/src/components/AuthPage/SignUp/index.js
@@ -27,7 +27,7 @@ const SignUp = ({ background = "white" }) => {
         <SmButtons />
         <Grid
           container
-          justify="center"
+          justifyContent="center"
           alignItems="center"
           className="mt-24"
           data-testId="signUpHaveAccount"

--- a/src/components/AuthPage/SignUp/signupForm.js
+++ b/src/components/AuthPage/SignUp/signupForm.js
@@ -176,7 +176,7 @@ const SignupForm = () => {
         </Collapse>
       )}
 
-      <Card data-testId="signUpForm" style={{ boxShadow: "none" }}>
+      <Card data-testid="signUpForm" style={{ boxShadow: "none" }}>
         <TextField
           label="Email"
           variant="outlined"
@@ -186,7 +186,7 @@ const SignupForm = () => {
           helperText={emailValidateError ? emailValidateErrorMessage : null}
           error={emailValidateError}
           fullWidth
-          data-testId="signUpEmail"
+          data-testid="signUpEmail"
           autoComplete="email"
           required
           onFocus={onFocusEmail}
@@ -209,7 +209,7 @@ const SignupForm = () => {
           value={password}
           onFocus={onFocusPassword}
           onChange={onChangePassword}
-          data-testId="signUpPassword"
+          data-testid="signUpPassword"
           autoComplete="new-password"
           type={showPassword ? "text" : "password"}
           style={{ marginBottom: "15px" }}
@@ -239,7 +239,7 @@ const SignupForm = () => {
           error={confirmPasswordValidateError}
           fullWidth
           required
-          data-testId="signUpConfirmPassword"
+          data-testid="signUpConfirmPassword"
           value={confirmPassword}
           onFocus={onFocusConfirmPassword}
           onChange={onChangeConfirmPassword}
@@ -279,7 +279,7 @@ const SignupForm = () => {
           color="primary"
           fullWidth
           disabled={loading}
-          data-testId="signUpButton"
+          data-testid="signUpButton"
           onClick={onSubmit}
         >
           {loading ? "Creating your account..." : "Create an account"}

--- a/src/components/AuthPage/index.js
+++ b/src/components/AuthPage/index.js
@@ -24,7 +24,7 @@ const AuthPage = ({ type }) => {
       container
       alignItems="center"
       style={{ overflowX: "hidden" }}
-      justify="center"
+      justifyContent="center"
       className="row-footer-below auth-margin"
     >
       <Grid item={true}>

--- a/src/components/AuthPage/smButton/smButtons.js
+++ b/src/components/AuthPage/smButton/smButtons.js
@@ -14,7 +14,7 @@ const SmButtons = () => {
   const firebase = useFirebase();
   const classes = useStyles();
   return (
-    <Grid container className={classes.root} data-testId="smButtons">
+    <Grid container className={classes.root} data-testid="smButtons">
       <Grid item>
         <img
           src={GoogleImg}

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -218,7 +218,7 @@ const Dashboard = ({ background = "white", textColor = "black" }) => {
 
   return (
     <div className="home-row" style={{ background: background }}>
-      <Grid container alignItems="center" justify="space-between">
+      <Grid container alignItems="center" justifyContent="space-between">
         <Grid xs={12} className="col-pad-24 pt-32" item={true}>
           <h2 className="mb-0 center" style={{ color: textColor }}>
             Welcome to CodeLabz!
@@ -230,7 +230,7 @@ const Dashboard = ({ background = "white", textColor = "black" }) => {
         <Grid xs={12} sm={12} md={showOrgForm ? 8 : 6} item={true}>
           {error && (
             <Grid container>
-              <Grid xs={12} className="col-pad-24 pr-12 pb-0">
+              <Grid item xs={12} className="col-pad-24 pr-12 pb-0">
                 <Alert variant="outlined" severity="error">
                   {error}
                 </Alert>

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -89,7 +89,7 @@ const Editor = ({ id, data, tutorial_id }) => {
         message="You have unsaved changes, are you sure you want to leave?"
       />
       <Grid>
-        <Grid xs={24} md={24}>
+        <Grid item xs={24} md={24}>
           <div id="firepad-container" ref={editorRef} />
         </Grid>
       </Grid>

--- a/src/components/ErrorPages/404.js
+++ b/src/components/ErrorPages/404.js
@@ -73,7 +73,7 @@ const NotFound = ({ background = "white", textColor = "black" }) => {
       container
       className={`row-fullheight ${classes.wrapper}`}
       style={{ background: background }}
-      data-testId="errorPage"
+      data-testid="errorPage"
     >
       <Grid
         item

--- a/src/components/ErrorPages/404.js
+++ b/src/components/ErrorPages/404.js
@@ -105,7 +105,7 @@ const NotFound = ({ background = "white", textColor = "black" }) => {
         </ul>
       </Grid>
       <Grid item style={{ marginTop: "0" }}>
-        <Typography variant="body" style={{ color: textColor }}>
+        <Typography variant="body1" style={{ color: textColor }}>
           We can't seem to find the page you are looking for
         </Typography>
       </Grid>

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -87,7 +87,7 @@ const Home = () => {
       <Grid
         container
         alignItems="center"
-        justify="center"
+        justifyContent="center"
         className="home-row mobile-top-padding mb-24"
         direction="row-reverse"
       >
@@ -120,7 +120,7 @@ const Home = () => {
       <Grid
         container
         className="light-grey-bg home-row"
-        justify="center"
+        justifyContent="center"
         align="center"
       >
         <Grid item xs={12} className="center pt-40 pb-40">
@@ -144,7 +144,7 @@ const Home = () => {
         container
         className="home-row pt-40 pb-40"
         align="middle"
-        justify="center"
+        justifyContent="center"
       >
         <Grid item xs={12} className="center mb-24">
           <h1 className="home-title mb-8">Learning made easier</h1>

--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -39,7 +39,7 @@ function HomePage({ background = "white", textColor = "black" }) {
               Popular Tags
             </Typography>
           </Grid>
-          <Grid container alignItems="left">
+          <Grid container alignItems="flex-start">
             <List component="nav" aria-label="mailbox folders" style={{ width: "100%" }}>
               <ListItem button>
                 <ListItemText primary="#javascript" />
@@ -76,7 +76,7 @@ function HomePage({ background = "white", textColor = "black" }) {
               Popular Events
             </Typography>
           </Grid>
-          <Grid container alignItems="left">
+          <Grid container alignItems="flex-start">
             <List component="nav" aria-label="mailbox folders" style={{ width: "100%" }}>
               <ListItem button>
                 <ListItemText primary="Lorem Pervious Text" />
@@ -124,8 +124,8 @@ function HomePage({ background = "white", textColor = "black" }) {
           </BottomNavigation>
         </Grid>
 
-        {userList.persons.map((person) => (
-          <CardComponent title={person.title} tags={person.tags} profilePic={person.profilePic} org={person.org} />
+        {userList.persons.map((person, index) => (
+          <CardComponent key={index} title={person.title} tags={person.tags} profilePic={person.profilePic} org={person.org} />
         ))}
       </div>
       <div className={classes.sideBody}>
@@ -142,7 +142,7 @@ function HomePage({ background = "white", textColor = "black" }) {
               Upcoming Events
             </Typography>
           </Grid>
-          <Grid container alignItems="left">
+          <Grid container alignItems="flex-start">
             <List
               component="nav"
               aria-label="mailbox folders"
@@ -180,7 +180,7 @@ function HomePage({ background = "white", textColor = "black" }) {
           <Typography variant="h6" gutterBottom style={{ marginBottom: "1rem", color: textColor }}>
             Discussion
           </Typography>
-          <Grid container alignItems="left">
+          <Grid container alignItems="flex-start">
             <List
               component="nav"
               aria-label="mailbox folders"

--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -19,7 +19,7 @@ function HomePage({ background = "white", textColor = "black" }) {
     setValue(newValue);
   };
   return (
-    <Card className={classes.wrapper} style={{ background: background }} data-testId="homepage">
+    <Card className={classes.wrapper} style={{ background: background }} data-testid="homepage">
       <div className={classes.sideBody}>
         <Grid
           container
@@ -31,7 +31,7 @@ function HomePage({ background = "white", textColor = "black" }) {
             overflow: "auto",
             maxHeight: "25rem",
           }}
-          data-testId="homepageTagSidebar"
+          data-testid="homepageTagSidebar"
         >
           <Grid item>
             <br />
@@ -68,7 +68,7 @@ function HomePage({ background = "white", textColor = "black" }) {
             overflow: "auto",
             maxHeight: "25rem",
           }}
-          data-testId="homepagePopularEventSidebar"
+          data-testid="homepagePopularEventSidebar"
         >
           <Grid item>
             <br />
@@ -97,7 +97,7 @@ function HomePage({ background = "white", textColor = "black" }) {
           </Grid>
         </Grid>
       </div>
-      <div className={classes.mainBody} data-testId="homepageMainBody">
+      <div className={classes.mainBody} data-testid="homepageMainBody">
         <Grid container className={classes.sort}>
           <Typography
             variant="h6"
@@ -115,7 +115,7 @@ function HomePage({ background = "white", textColor = "black" }) {
             className={classes.sortedList}
             value={value}
             onChange={handleChange}
-            data-testId="sortByTime"
+            data-testid="sortByTime"
           >
             <BottomNavigationAction label="Week" />
             <BottomNavigationAction label="Month" style={{ fontSize: "2rem" }} />
@@ -135,7 +135,7 @@ function HomePage({ background = "white", textColor = "black" }) {
           alignContent="center"
           direction="column"
           style={{ padding: "1rem" }}
-          data-testId="homepageUpcomingEventSidebar"
+          data-testid="homepageUpcomingEventSidebar"
         >
           <Grid item>
             <Typography variant="h6" gutterBottom style={{ marginBottom: "1rem", color: textColor }}>
@@ -175,7 +175,7 @@ function HomePage({ background = "white", textColor = "black" }) {
           alignContent="center"
           direction="column"
           style={{ padding: "1rem" }}
-          data-testId="homepageDiscussionSidebar"
+          data-testid="homepageDiscussionSidebar"
         >
           <Typography variant="h6" gutterBottom style={{ marginBottom: "1rem", color: textColor }}>
             Discussion

--- a/src/components/ManageUsers/ResetPassword/PasswordResetForm.js
+++ b/src/components/ManageUsers/ResetPassword/PasswordResetForm.js
@@ -67,7 +67,7 @@ const PasswordResetForm = ({ actionCode }) => {
             closable
             className="mb-16"
           />
-          <Grid justify="center" align="center" className="mt-24">
+          <Grid justifyContent="center" align="center" className="mt-24">
             <Grid sm={24} className="center">
               <Link to={"/login"}>Sign in</Link>
             </Grid>
@@ -125,7 +125,7 @@ const PasswordResetForm = ({ actionCode }) => {
               </Button>
             </FormControl>
           </form>
-          <Grid justify="center" align="center" className="mt-24">
+          <Grid justifyContent="center" align="center" className="mt-24">
             <Grid sm={24} className="center">
               Back to <Link to={"/login"}>CodeLabz</Link>
             </Grid>

--- a/src/components/ManageUsers/ResetPassword/index.js
+++ b/src/components/ManageUsers/ResetPassword/index.js
@@ -53,7 +53,7 @@ const ResetPassword = ({ queryParams = "test" }) => {
 
   return (
     <>
-      <Grid justify="center">
+      <Grid justifyContent="center">
         <Grid md={12} lg={10}>
           <Card bordered={false}>
             {loading && (
@@ -74,7 +74,7 @@ const ResetPassword = ({ queryParams = "test" }) => {
                   className="mb-16"
                   showIcon
                 />
-                <Grid justify="center" align="center" className="mt-24">
+                <Grid justifyContent="center" align="center" className="mt-24">
                   <Grid className="center">
                     Back to <Link to={"/login"}>CodeLabz</Link>
                   </Grid>

--- a/src/components/ManageUsers/VerifyEmail/index.js
+++ b/src/components/ManageUsers/VerifyEmail/index.js
@@ -47,8 +47,8 @@ const VerifyEmail = ({ queryParams = "test" }) => {
 
   return (
     <>
-      <Grid justify="center">
-        <Grid xs={24} sm={24} md={12} lg={10}>
+      <Grid justifyContent="center">
+        <Grid item xs={24} sm={24} md={12} lg={10}>
           <Card bordered={false}>
             {loading && (
               <Typography
@@ -64,7 +64,7 @@ const VerifyEmail = ({ queryParams = "test" }) => {
                 <Alert severity="error" closable className="mb-16" showIcon>
                   Verification failed
                 </Alert>
-                <Grid justify="center" align="center" className="mt-24">
+                <Grid justifyContent="center" align="center" className="mt-24">
                   <Grid sm={24} className="center">
                     Back to <Link to={"/login"}>CodeLabz</Link>
                   </Grid>
@@ -77,7 +77,7 @@ const VerifyEmail = ({ queryParams = "test" }) => {
                 <Alert severity="success" closable className="mb-16" showIcon>
                   Your email has been verified!
                 </Alert>
-                <Grid justify="center" align="center" className="mt-24">
+                <Grid justifyContent="center" align="center" className="mt-24">
                   <Grid sm={24} className="center">
                     <Link to={"/login"}>Log in</Link>
                   </Grid>

--- a/src/components/MyFeed/Carousel/index.js
+++ b/src/components/MyFeed/Carousel/index.js
@@ -49,13 +49,13 @@ const Carousel = () => {
     <section className={classes.slides}>
       <ArrowBackIosIcon
         onClick={prevSlide}
-        data-testId="codefeedLeftarrow"
+        data-testid="codefeedLeftarrow"
         className={classes.arrow}
         style={{ position: "absolute", left: "-1rem" }}
       />
       <ChevronRightIcon
         onClick={nextSlide}
-        data-testId="codefeedRightarrow"
+        data-testid="codefeedRightarrow"
         className={classes.arrow}
         style={{ position: "absolute", right: "-1rem", fontSize: "2.3rem" }}
       />
@@ -78,7 +78,7 @@ const Carousel = () => {
                       style={{
                         zIndex: -1,
                       }}
-                      data-testId="codefeedCarouselCard"
+                      data-testid="codefeedCarouselCard"
                     >
                       <CardActionArea>
                         <CardMedia

--- a/src/components/MyFeed/index.js
+++ b/src/components/MyFeed/index.js
@@ -21,7 +21,7 @@ const MyFeed = ({
           spacing={0}
           direction="column"
           alignItems="center"
-          justify="center"
+          justifyContent="center"
           style={{ padding: "15px" }}
           data-testId="codefeedTitle"
         >

--- a/src/components/MyFeed/index.js
+++ b/src/components/MyFeed/index.js
@@ -23,7 +23,7 @@ const MyFeed = ({
           alignItems="center"
           justifyContent="center"
           style={{ padding: "15px" }}
-          data-testId="codefeedTitle"
+          data-testid="codefeedTitle"
         >
           <Typography variant="h2" style={{ color: textcolor }}>
             {heading}

--- a/src/components/NavBar/MainNavbar/index.js
+++ b/src/components/NavBar/MainNavbar/index.js
@@ -46,7 +46,7 @@ function MainNavbar() {
   }));
   const classes = useStyles();
   return (
-    <Headroom style={{ height: "66px" }} data-testId="mainNavbar">
+    <Headroom style={{ height: "66px" }} data-testid="mainNavbar">
       <nav className="navbar">
         <Grid container>
           <Grid className={classes.navHeader} style={{ width: "100%" }}>

--- a/src/components/NavBar/MiniNavbar/index.js
+++ b/src/components/NavBar/MiniNavbar/index.js
@@ -20,7 +20,7 @@ const MiniNavbar = ({ type }) => {
         data-testId="miniNavbar"
         container
         direction="row"
-        justify="space-between"
+        justifyContent="space-between"
         alignItems="center"
       >
         <Grid item>

--- a/src/components/NavBar/MiniNavbar/index.js
+++ b/src/components/NavBar/MiniNavbar/index.js
@@ -17,7 +17,7 @@ const MiniNavbar = ({ type }) => {
   return (
     <Headroom>
       <Grid
-        data-testId="miniNavbar"
+        data-testid="miniNavbar"
         container
         direction="row"
         justifyContent="space-between"

--- a/src/components/Organization/OrgInfoCard/editOrgDetailsModal.js
+++ b/src/components/Organization/OrgInfoCard/editOrgDetailsModal.js
@@ -92,7 +92,7 @@ const EditOrgDetailsModal = ({ currentOrgData, modelCloseCallback }) => {
   return (
     <>
       {error && <Alert severity="error">Error!</Alert>}
-      <form onSubmit={onSubmit} data-testId="editOrgForm">
+      <form onSubmit={onSubmit} data-testid="editOrgForm">
         <label className="form-label">Organization Name</label>
         <TextField
           variant="outlined"

--- a/src/components/Organization/OrgInfoCard/orgInfoCard.js
+++ b/src/components/Organization/OrgInfoCard/orgInfoCard.js
@@ -285,7 +285,7 @@ const OrgInfoCard = () => {
                 </Dialog>
               </Card>
             </Grid>
-            <Grid xs={24} md={16} lg={16} className="pl-24-d pt-24-m" data-testId="orgInfoCard">
+            <Grid item xs={24} md={16} lg={16} className="pl-24-d pt-24-m" data-testId="orgInfoCard">
               <p>
                 <span style={{ fontSize: "1.3em", fontWeight: "bold" }}>{currentOrgData.org_name}</span>
               </p>

--- a/src/components/Organization/OrgInfoCard/orgInfoCard.js
+++ b/src/components/Organization/OrgInfoCard/orgInfoCard.js
@@ -198,7 +198,7 @@ const OrgInfoCard = () => {
                   maxWidth="sm"
                   open={showImageDialog}
                   onClose={!showImageDialog}
-                  data-testId="changeOrgImgDialog"
+                  data-testid="changeOrgImgDialog"
                 >
                   <DialogTitle id="alert-dialog-title">
                     <span style={{ fontSize: "1.3em", fontWeight: "480" }}>{"Change Profile Picture"}</span>
@@ -285,7 +285,7 @@ const OrgInfoCard = () => {
                 </Dialog>
               </Card>
             </Grid>
-            <Grid item xs={24} md={16} lg={16} className="pl-24-d pt-24-m" data-testId="orgInfoCard">
+            <Grid item xs={24} md={16} lg={16} className="pl-24-d pt-24-m" data-testid="orgInfoCard">
               <p>
                 <span style={{ fontSize: "1.3em", fontWeight: "bold" }}>{currentOrgData.org_name}</span>
               </p>

--- a/src/components/Organization/OrgSidebar/orgIcons.js
+++ b/src/components/Organization/OrgSidebar/orgIcons.js
@@ -34,12 +34,12 @@ export const OrgIcons = ({
   }
 
   return (
-    <Grid type="flex" align="middle" justify="space-around">
-      <Grid xs={24}>
+    <Grid type="flex" align="middle" justifyContent="space-around">
+      <Grid item xs={24}>
         <Tooltip {...tooltipProps}>
           <Grid
             align="middle"
-            justify={isDesktop ? "space-around" : null}
+            justifyContent={isDesktop ? "space-around" : null}
             onClick={onClick && data ? () => onClick(data) : null}
           >
             <Grid>

--- a/src/components/Organization/OrgSidebar/orgSidebar.js
+++ b/src/components/Organization/OrgSidebar/orgSidebar.js
@@ -90,7 +90,7 @@ const OrgSidebar = ({ onOrgChange }) => {
       {orgs &&
         orgs.map((org) => (
           <Palette
-            data-testId="orgSidebarIcon"
+            data-testid="orgSidebarIcon"
             src={org.org_image}
             crossOrigin="Anonymous"
             key={org.org_handle}

--- a/src/components/Organization/OrgUsersCard/addOrgUserModal.js
+++ b/src/components/Organization/OrgUsersCard/addOrgUserModal.js
@@ -124,7 +124,7 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
         )}
       />
       {console.log(users)}
-      <Grid container justify="flex-end">
+      <Grid container justifyContent="flex-end">
         <div style={{ padding: "10px" }}>
           <span style={{ paddingRight: "10px" }}>Select user role</span>
           <Select value={selected} onChange={handlePermissionChange}>

--- a/src/components/Organization/OrgUsersCard/orgUsersCard.js
+++ b/src/components/Organization/OrgUsersCard/orgUsersCard.js
@@ -267,7 +267,7 @@ const OrgUsersCard = () => {
             )
           }
         />{" "}
-        <Box mt={2} mb={2} m={3} data-testId="orgUserCard">
+        <Box mt={2} mb={2} m={3} data-testid="orgUserCard">
           <Grid xs={12} md={12} lg={12} item={true}>
             <List
               subheader={

--- a/src/components/Organization/ViewOrganization/index.js
+++ b/src/components/Organization/ViewOrganization/index.js
@@ -7,7 +7,7 @@ import Button from "@material-ui/core/Button";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import Box from "@material-ui/core/Box";
 import ThemeProvider from "@material-ui/core/styles/MuiThemeProvider";
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createTheme } from "@material-ui/core/styles";
 import FacebookIcon from "@material-ui/icons/Facebook";
 import TwitterIcon from "@material-ui/icons/Twitter";
 import GitHubIcon from "@material-ui/icons/GitHub";
@@ -24,7 +24,7 @@ import {
   removeFollower,
 } from "../../../store/actions";
 
-const theme = createMuiTheme({
+const theme = createTheme({
   shadows: ["none"],
   palette: {
     primary: {

--- a/src/components/Organization/index.js
+++ b/src/components/Organization/index.js
@@ -34,7 +34,7 @@ const Organizations = () => {
           onClose={() => setDrawerVisible(false)}
         >
           <Grid>
-            <Grid xs={24} className="col-pad-24-s pt-0">
+            <Grid item xs={24} className="col-pad-24-s pt-0">
               <OrgSidebar
                 onOrgChange={() => {
                   setDrawerVisible(false);
@@ -48,7 +48,7 @@ const Organizations = () => {
       <Grid>
         {!isDesktop && (
           <Grid>
-            <Grid xs={24} className="col-pad-24-s pb-0">
+            <Grid item xs={24} className="col-pad-24-s pb-0">
               <Button
                 onClick={() => setDrawerVisible(true)}
                 block
@@ -61,10 +61,10 @@ const Organizations = () => {
           </Grid>
         )}
         <Grid className={classes.cardBody}>
-          <Grid xs={24} sm={24} md={14} className="col-pad-24-s pr-12">
+          <Grid item xs={24} sm={24} md={14} className="col-pad-24-s pr-12">
             <OrgInfoCard />
           </Grid>
-          <Grid xs={24} sm={24} md={10} className="col-pad-24-s pl-12">
+          <Grid item xs={24} sm={24} md={10} className="col-pad-24-s pl-12">
             <OrgUsersCard />
           </Grid>
         </Grid>

--- a/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
+++ b/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
@@ -233,7 +233,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           variant="outlined"
           placeholder="Display Name"
           value={name}
-          data-testId="editProfileName"
+          data-testid="editProfileName"
           onChange={(event) => onChangeName(event.target.value)}
           helperText={nameValidateError ? nameValidateErrorMessage : null}
           fullWidth
@@ -270,7 +270,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           variant="outlined"
           placeholder="Website"
           value={website}
-          data-testId="editProfileWebsite"
+          data-testid="editProfileWebsite"
           onChange={(event) => onChangeOrgWebsite(event.target.value)}
           helperText={websiteValidateError ? websiteValidateErrorMessage : null}
           fullWidth
@@ -294,7 +294,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           multiline
           variant="outlined"
           placeholder="Description"
-          data-testId="editProfileDescription"
+          data-testid="editProfileDescription"
           value={description}
           onChange={(event) => onChangeDescription(event.target.value)}
           helperText={
@@ -321,7 +321,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           variant="outlined"
           placeholder="username"
           value={facebook}
-          data-testId="editProfileFacebook"
+          data-testid="editProfileFacebook"
           onChange={(event) => onChangeFacebook(event.target.value)}
           helperText={
             facebookValidateError ? facebookValidateErrorMessage : null
@@ -350,7 +350,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           variant="outlined"
           value={twitter}
           placeholder="username"
-          data-testId="editProfileTwitter"
+          data-testid="editProfileTwitter"
           onChange={(event) => onChangeTwitter(event.target.value)}
           helperText={twitterValidateError ? twitterValidateErrorMessage : null}
           fullWidth
@@ -376,7 +376,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           label="LinkedIn"
           variant="outlined"
           value={linkedin}
-          data-testId="editProfileLinkedin"
+          data-testid="editProfileLinkedin"
           placeholder="username"
           onChange={(event) => onChangeLinkedin(event.target.value)}
           helperText={
@@ -409,7 +409,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
           onChange={(event) => onChangeGithub(event.target.value)}
           helperText={githubValidateError ? githubValidateErrorMessage : null}
           fullWidth
-          data-testId="editProfileGithub"
+          data-testid="editProfileGithub"
           autoComplete="handle"
           required
           style={{ marginBottom: "15px" }}
@@ -439,7 +439,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
               style={{
                 backgroundColor: "SeaGreen",
               }}
-              data-testId="editProfileSave"
+              data-testid="editProfileSave"
               onClick={onSubmit}
             >
               {loading ? "Saving..." : "Save"}

--- a/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
+++ b/src/components/Profile/ProfileInfoCard/editProfileDetailsModal.js
@@ -216,7 +216,7 @@ const EditProfileDetailsModal = ({ profileData, modelCloseCallback }) => {
     <Grid id="editModalBox">
       {error && (
         <Grid container>
-          <Grid xs={12} className="col-pad-24 pr-12 pb-0">
+          <Grid item xs={12} className="col-pad-24 pr-12 pb-0">
             <Alert variant="outlined" severity="error">
               {error}
             </Alert>

--- a/src/components/Profile/ProfileInfoCard/index.js
+++ b/src/components/Profile/ProfileInfoCard/index.js
@@ -280,7 +280,7 @@ const ProfileInfoCard = () => {
           <Grid xs={12} md={9} lg={9} item={true}>
             <Box mt={6} mb={2} m={3} id="profileData">
               <p>
-                <span style={{ fontSize: "1.3em", fontWeight: "bold" }} data-testId="profileName">
+                <span style={{ fontSize: "1.3em", fontWeight: "bold" }} data-testid="profileName">
                   {profileData.displayName}
                   <Box>
                     {verified ? (

--- a/src/components/Tutorials/MyTutorials/BaseTutorialsComponent/TutorialCard.js
+++ b/src/components/Tutorials/MyTutorials/BaseTutorialsComponent/TutorialCard.js
@@ -13,7 +13,7 @@ import { Link } from "react-router-dom";
 
 const TutorialCard = ({ tutorialData: { tutorial_id, title, summary, icon, owner }, loading }) => {
   return (
-    <Card style={{ height: "100%" }} data-testId="tutorialCard">
+    <Card style={{ height: "100%" }} data-testid="tutorialCard">
       <CardActionArea>
         <CardMedia
           component="img"

--- a/src/components/Tutorials/MyTutorials/BaseTutorialsComponent/index.js
+++ b/src/components/Tutorials/MyTutorials/BaseTutorialsComponent/index.js
@@ -60,8 +60,8 @@ const BaseTutorialsComponent = ({ owner = "", ownerName = "", users = [] }) => {
     );
   } else {
     return (
-      <Grid justify="center" align="center">
-        <Grid xs={12} className="col-pad-24">
+      <Grid justifyContent="center" align="center">
+        <Grid item xs={12} className="col-pad-24">
           <Spinner half />
         </Grid>
       </Grid>

--- a/src/components/Tutorials/MyTutorials/OrgTutorials/index.js
+++ b/src/components/Tutorials/MyTutorials/OrgTutorials/index.js
@@ -41,7 +41,7 @@ const OrgTutorialsComponent = ({ organizations, user }) => {
     });
 
     return (
-      <TabPanel data-testId="tutorialOrgComponent">
+      <TabPanel data-testid="tutorialOrgComponent">
         <Tabs onSelect={onSelectTab}>
           {arr.map((org) => (
             <Tab label={org.name} key={0} icon={<Avatar alt={org.name} src={org.image} />}></Tab>

--- a/src/components/Tutorials/MyTutorials/Search/SearchResultsComponent.js
+++ b/src/components/Tutorials/MyTutorials/Search/SearchResultsComponent.js
@@ -7,14 +7,14 @@ import TutorialCard from '../BaseTutorialsComponent/TutorialCard';
 const SearchResultsComponent = ({ results }) => {
   return (
     <div>
-      <Grid container item justify="center">
+      <Grid container item justifyContent="center">
         <Divider variant="middle" />
         <Grid item xs={12}>
           <Typography align="center"> Search Results</Typography>
         </Grid>
         <Divider variant="middle" />
         {results.map((tutorial, index) => (
-          <Grid xs={12} sm={6} md={3} lg={2} xl={2} className="pr-24">
+          <Grid item xs={12} sm={6} md={3} lg={2} xl={2} className="pr-24">
             <TutorialCard key={index} tutorialData={tutorial} loading={false} />
           </Grid>
         ))}

--- a/src/components/Tutorials/MyTutorials/Search/index.js
+++ b/src/components/Tutorials/MyTutorials/Search/index.js
@@ -62,8 +62,8 @@ const SearchComponent = () => {
     setVisibleModal((prev) => !prev);
   };
   return (
-    <Grid container item justify="space-between" data-testId="tutorialSearch">
-      <Grid xs={12} md={3} className="col-pad-24">
+    <Grid container item justifyContent="space-between" data-testId="tutorialSearch">
+      <Grid item xs={12} md={3} className="col-pad-24">
         <Button
           variant="contained"
           onClick={() => setVisibleModal(true)}
@@ -76,7 +76,7 @@ const SearchComponent = () => {
         </Button>
         <NewTutorial viewModal={visibleModal} onSidebarClick={(e) => closeModal(e)} />
       </Grid>
-      <Grid xs={12} md={4} className="col-pad-24">
+      <Grid item xs={12} md={4} className="col-pad-24">
         <TextField
           placeholder="Search CodeLabz by title, summary, or owner"
           onKeyUp={handleOnSearch}
@@ -91,7 +91,7 @@ const SearchComponent = () => {
         />
       </Grid>
       {viewResults && (
-        <Grid xs={12} className={"mb-24 "}>
+        <Grid item xs={12} className={"mb-24 "}>
           <SearchResultsComponent results={results} />
         </Grid>
       )}

--- a/src/components/Tutorials/MyTutorials/Search/index.js
+++ b/src/components/Tutorials/MyTutorials/Search/index.js
@@ -62,14 +62,14 @@ const SearchComponent = () => {
     setVisibleModal((prev) => !prev);
   };
   return (
-    <Grid container item justifyContent="space-between" data-testId="tutorialSearch">
+    <Grid container item justifyContent="space-between" data-testid="tutorialSearch">
       <Grid item xs={12} md={3} className="col-pad-24">
         <Button
           variant="contained"
           onClick={() => setVisibleModal(true)}
           color="primary"
           startIcon={<Add />}
-          data-testId="tutorialAddNewButton"
+          data-testid="tutorialAddNewButton"
           style={{ backgroundColor: "royalblue" }}
         >
           Add New CodeLabz

--- a/src/components/Tutorials/MyTutorials/index.js
+++ b/src/components/Tutorials/MyTutorials/index.js
@@ -74,7 +74,7 @@ const MyTutorials = () => {
   };
 
   return (
-    <div className="row-footer-below" data-testId="tutorialMainBody">
+    <div className="row-footer-below" data-testid="tutorialMainBody">
       <Grid container>
         <Grid item xs={12} className="mb-24">
           <SearchComponent />

--- a/src/components/Tutorials/MyTutorials/index.js
+++ b/src/components/Tutorials/MyTutorials/index.js
@@ -76,11 +76,11 @@ const MyTutorials = () => {
   return (
     <div className="row-footer-below" data-testId="tutorialMainBody">
       <Grid container>
-        <Grid xs={12} className="mb-24">
+        <Grid item xs={12} className="mb-24">
           <SearchComponent />
         </Grid>
         {organizations && organizations.length > 0 && (
-          <Grid xs={12} className="m-24">
+          <Grid item xs={12} className="m-24">
             <OrgTutorialsComponent
               organizations={organizations}
               user={userDetails}

--- a/src/components/Tutorials/NewTutorial/index.js
+++ b/src/components/Tutorials/NewTutorial/index.js
@@ -141,7 +141,7 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
       }}
     >
       <div
-        data-testId="tutorialNewModal"
+        data-testid="tutorialNewModal"
         style={{
           height: "auto",
           width: "auto",

--- a/src/components/Tutorials/index.js
+++ b/src/components/Tutorials/index.js
@@ -115,7 +115,7 @@ const ViewTutorial = () => {
       <Grid className="row-footer-below">
         {allowEdit && (
           <Grid>
-            <Grid xs={24} sm={24} md={24}>
+            <Grid item xs={24} sm={24} md={24}>
               <EditControls
                 stepPanelVisible={stepPanelVisible}
                 isDesktop={isDesktop}
@@ -137,7 +137,7 @@ const ViewTutorial = () => {
         )}
 
         <Grid>
-          <Grid xs={24} sm={24} md={24}>
+          <Grid item xs={24} sm={24} md={24}>
             <TutorialTitle
               stepPanelVisible={stepPanelVisible}
               isDesktop={isDesktop}
@@ -163,7 +163,7 @@ const ViewTutorial = () => {
           </Grid>
 
           <Grid style={{ width: "90%", background: "#f0f0f0" }}>
-            <Grid className="tutorial-content" justify="center" container>
+            <Grid className="tutorial-content" justifyContent="center" container>
               <Grid
                 xs={24}
                 sm={24}
@@ -224,7 +224,7 @@ const ViewTutorial = () => {
               />
             </Grid>
             <Grid>
-              <Grid xs={24} sm={24} md={24} className="col-pad-24-s">
+              <Grid item xs={24} sm={24} md={24} className="col-pad-24-s">
                 <ControlButtons
                   currentStep={currentStep}
                   setCurrentStep={setCurrentStep}

--- a/src/components/Tutorials/subComps/ColorPickerModal.js
+++ b/src/components/Tutorials/subComps/ColorPickerModal.js
@@ -53,8 +53,9 @@ const ColorPickerModal = ({ visible, visibleCallback, tutorial_id, owner }) => {
         }}
       >
         <Grid>
-          <Grid align="middle" justify="center" className="mb-24">
+          <Grid align="middle" justifyContent="center" className="mb-24">
             <Grid
+              item
               xs={24}
               md={12}
               className="mb-16"
@@ -70,6 +71,7 @@ const ColorPickerModal = ({ visible, visibleCallback, tutorial_id, owner }) => {
               </div>
             </Grid>
             <Grid
+              item
               xs={24}
               md={12}
               className="mb-16"
@@ -97,7 +99,7 @@ const ColorPickerModal = ({ visible, visibleCallback, tutorial_id, owner }) => {
             }}
             align="middle"
           >
-            <Grid xs={24} style={{ textAlign: "center" }}>
+            <Grid item xs={24} style={{ textAlign: "center" }}>
               Change the values above to see the preview
             </Grid>
           </Grid>

--- a/src/components/Tutorials/subComps/ImageDrawer.js
+++ b/src/components/Tutorials/subComps/ImageDrawer.js
@@ -169,10 +169,10 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
           imageURLs.length > 0 &&
           imageURLs.map((image, i) => (
             <Grid className="mb-24" key={i}>
-              <Grid xs={24} md={8}>
+              <Grid item xs={24} md={8}>
                 <img src={image.url} alt="" />
               </Grid>
-              <Grid xs={24} md={16} className="pl-8" style={{}}>
+              <Grid item xs={24} md={16} className="pl-8" style={{}}>
                 <h4 className="pb-8">{image.name}</h4>
 
                 <CopyToClipboard

--- a/src/components/Tutorials/subComps/ImageDrawer.js
+++ b/src/components/Tutorials/subComps/ImageDrawer.js
@@ -140,7 +140,7 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
       destroyOnClose={true}
       maskClosable={false}
     >
-      <div className="col-pad-24" data-testId="tutorialImgUpload">
+      <div className="col-pad-24" data-testid="tutorialImgUpload">
         <Grid>
           <input
             id="file-upload"

--- a/src/components/Tutorials/subComps/StepsTitle.js
+++ b/src/components/Tutorials/subComps/StepsTitle.js
@@ -114,10 +114,10 @@ const StepsTitle = ({ owner, tutorial_id }) => {
 
   return (
     <Grid>
-      <Grid xs={24}>
+      <Grid item xs={24}>
         <form>
           <Grid style={{ width: "100%" }}>
-            <Grid xs={24} md={19}>
+            <Grid item xs={24} md={19}>
               <Input
                 onBlur={setStepTitle}
                 onPressEnter={setStepTitle}
@@ -127,7 +127,7 @@ const StepsTitle = ({ owner, tutorial_id }) => {
                 prefix={current_step_no + 1 + "."}
               />
             </Grid>
-            <Grid xs={24} md={5}>
+            <Grid item xs={24} md={5}>
               <Input
                 onBlur={setStepTime}
                 onPressEnter={setStepTime}

--- a/src/components/util/CodelabCard/index.js
+++ b/src/components/util/CodelabCard/index.js
@@ -27,9 +27,9 @@ const CardComponent = ({
 
   return (
     <>
-      <Card className={classes.card} style={{ background: background ,maxWidth : "sm" }} data-testId="codelabzCard">
+      <Card className={classes.card} style={{ background: background ,maxWidth : "sm" }} data-testid="codelabzCard">
         <CardHeader
-          data-testId="codelabzCardHeader"
+          data-testid="codelabzCardHeader"
           className={classes.cardHeader}
           avatar={
             <Grid
@@ -71,7 +71,7 @@ const CardComponent = ({
           subheaderTypographyProps={{ align: "left" }}
         />
         <CardContent
-          data-testId="codelabzCardContent"
+          data-testid="codelabzCardContent"
           className={classes.cardContent}
           style={{ paddingBottom: "0rem" }}
         >
@@ -89,7 +89,7 @@ const CardComponent = ({
           </Grid>
         </CardContent>
         <CardActions disableSpacing className={classes.cardAction}>
-          <Grid container justifyContent="flex-start" direction="row" data-testId="codelabzCardButtonGroup">
+          <Grid container justifyContent="flex-start" direction="row" data-testid="codelabzCardButtonGroup">
             <Grid item style={{ display : "flex", flexDirection : "row"}}> 
               {!org ? (
                 <Grid item style={{ height: "2rem" }}>

--- a/src/components/util/CodelabCard/index.js
+++ b/src/components/util/CodelabCard/index.js
@@ -27,7 +27,7 @@ const CardComponent = ({
 
   return (
     <>
-      <Card maxWidth="sm" className={classes.card} style={{ background: background }} data-testId="codelabzCard">
+      <Card className={classes.card} style={{ background: background ,maxWidth : "sm" }} data-testId="codelabzCard">
         <CardHeader
           data-testId="codelabzCardHeader"
           className={classes.cardHeader}
@@ -36,7 +36,7 @@ const CardComponent = ({
               container
               className={classes.organizationLogo}
               direction="column"
-              justify="center"
+              justifyContent="center"
               alignItems="center"
             >
               {logoPath ? (
@@ -59,11 +59,11 @@ const CardComponent = ({
           }
           title={
             org ? (
-              <Typography variant="body">
+              <Typography>
                 Demo Name {<span style={{ color: "#7D7C7D" }}>for</span>} ScoreLabz
               </Typography>
             ) : (
-              <Typography variant="body">Demo Name</Typography>
+              <Typography>Demo Name</Typography>
             )
           }
           subheader="May25,2021(3 days ago)"
@@ -75,13 +75,13 @@ const CardComponent = ({
           className={classes.cardContent}
           style={{ paddingBottom: "0rem" }}
         >
-          <Grid container alignItems="left" justify="flex-start" direction="column" className={classes.body}>
+          <Grid container alignItems="flex-start" justifyContent="flex-start" direction="column" className={classes.body}>
             <Grid item>
               <Typography variant="h5" gutterBottom className={classes.heading}>
                 {title}
               </Typography>
             </Grid>
-            <Grid container direction="row" justify="flex-start" alignItems="left">
+            <Grid container direction="row" justifyContent="flex-start" alignItems="flex-start">
               <Typography variant="body2" color="textPrimary" className={"mr-8 " + classes.tags}>
                 {tags}
               </Typography>
@@ -89,14 +89,14 @@ const CardComponent = ({
           </Grid>
         </CardContent>
         <CardActions disableSpacing className={classes.cardAction}>
-          <Grid container xs={6} justify="left" direction="row" data-testId="codelabzCardButtonGroup">
-            <Grid item direction="row">
+          <Grid container justifyContent="flex-start" direction="row" data-testId="codelabzCardButtonGroup">
+            <Grid item style={{ display : "flex", flexDirection : "row"}}> 
               {!org ? (
                 <Grid item style={{ height: "2rem" }}>
                   <IconButton style={{ color: "red" }}>
                     <FavoriteIcon />
                   </IconButton>
-                  <Typography variant="body" color="textPrimary">
+                  <Typography variant="button" color="textPrimary">
                     222
                   </Typography>
                 </Grid>
@@ -109,19 +109,18 @@ const CardComponent = ({
                 <ChatIcon />
               </IconButton>
               {org ? (
-                <Typography variant="body" color="textPrimary">
+                <Typography variant="button" color="textPrimary">
                   comment
                 </Typography>
               ) : (
-                <Typography variant="body" color="textPrimary">
+                <Typography variant="button" color="textPrimary">
                   20
                 </Typography>
               )}
             </Grid>
-          </Grid>
-          <Grid xs={6} container direction="row" justify="flex-end" alignItems="center">
+          <Grid container direction="row" justifyContent="flex-end" alignItems="center">
             <Grid item xs={3}>
-              <Typography variant="body2" color="textSecondary" alignItems="flex-end" className={classes.readTime}>
+              <Typography variant="subtitle1" color="textSecondary" className={classes.readTime}>
                 10 min read
               </Typography>
             </Grid>
@@ -131,6 +130,7 @@ const CardComponent = ({
               </Button>
             </Grid>
           </Grid>
+        </Grid>
         </CardActions>
       </Card>
     </>

--- a/src/components/util/CodelabCard/styles.js
+++ b/src/components/util/CodelabCard/styles.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: "0rem",
     [theme.breakpoints.down(750)]: {
       padding: "0rem 1rem 0rem 1rem",
-      justify: "center",
+      justifyContent: "center",
       textAlign: "left",
     },
   },

--- a/src/helpers/appBar.js
+++ b/src/helpers/appBar.js
@@ -149,14 +149,14 @@ const CodeLabzAppBar = () => {
 
   if (authed) {
     return (
-      <div className={classes.grow} data-testId="navbarloggedIn">
+      <div className={classes.grow} data-testid="navbarloggedIn">
         <AppBar position="static" color="white">
           <Toolbar className={classes.toolbar}>
             <Typography
               className={classes.title}
               variant="h6"
               noWrap
-              data-testId="navbarBrand"
+              data-testid="navbarBrand"
             >
               <Link to={"/"}>
                 <BrandName />
@@ -169,7 +169,7 @@ const CodeLabzAppBar = () => {
               </div>
 
               <InputBase
-                data-testId="navbarSearch"
+                data-testid="navbarSearch"
                 placeholder="Search"
                 classes={{
                   root: classes.inputRoot,
@@ -202,7 +202,7 @@ const CodeLabzAppBar = () => {
               aria-label="appsIcon"
               className={classes.margin}
               onClick={handleMenuOpen}
-              data-testId="navbarAppMenu"
+              data-testid="navbarAppMenu"
             >
               <AppsIcon fontSize="large" />
             </IconButton>
@@ -221,14 +221,14 @@ const CodeLabzAppBar = () => {
     );
   } else {
     return (
-      <div className={classes.grow} data-testId="navbarNonloggedIn">
+      <div className={classes.grow} data-testid="navbarNonloggedIn">
         <AppBar position="static" color="secondary">
           <Toolbar className={classes.toolbar}>
             <Typography
               className={classes.title}
               variant="h6"
               noWrap
-              data-testId="navbarBrand"
+              data-testid="navbarBrand"
             >
               <Link to={"/"}>
                 <BrandName />
@@ -240,7 +240,7 @@ const CodeLabzAppBar = () => {
               </div>
 
               <InputBase
-                data-testId="navbarSearch"
+                data-testid="navbarSearch"
                 placeholder="Search"
                 classes={{
                   root: classes.inputRoot,
@@ -271,7 +271,7 @@ const CodeLabzAppBar = () => {
                 variant="contained"
                 color="primary"
                 style={{ backgroundColor: "royalblue" }}
-                data-testId="navbarlogin"
+                data-testid="navbarlogin"
               >
                 Log In
               </Button>

--- a/src/helpers/appBar.js
+++ b/src/helpers/appBar.js
@@ -51,6 +51,7 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(1),
     marginLeft: 0,
     width: "50%",
+    color : "black",
 
     // If not mobile size
     [theme.breakpoints.up("md")]: {
@@ -221,7 +222,7 @@ const CodeLabzAppBar = () => {
   } else {
     return (
       <div className={classes.grow} data-testId="navbarNonloggedIn">
-        <AppBar position="static" color="white">
+        <AppBar position="static" color="secondary">
           <Toolbar className={classes.toolbar}>
             <Typography
               className={classes.title}

--- a/src/helpers/emptyTutorials.js
+++ b/src/helpers/emptyTutorials.js
@@ -12,7 +12,7 @@ const EmptyTutorials = ({ org, orgHandle }) => {
     setVisibleModal((prev) => !prev);
   };
   return (
-    <Grid xs={24}>
+    <Grid item xs={24}>
       <Grid
         style={{ display: "flex", flexFlow: "column", background: "#f2f2f2" }}
         description={<span>{org} has no CodeLabz yet</span>}

--- a/src/helpers/spinner.js
+++ b/src/helpers/spinner.js
@@ -5,12 +5,12 @@ import BrandName from "./brandName";
 const Spinner = ({ half }) => {
   return (
     <Grid
-      justify={"center"}
+      justifyContent={"center"}
       style={{ minHeight: half ? "50vh" : "100vh" }}
       alignItems="center"
       container
     >
-      <Grid xs={12} style={{ textAlign: "center" }}>
+      <Grid item xs={12} style={{ textAlign: "center" }}>
         <div className="pulse">
           <BrandName />
         </div>

--- a/src/helpers/themes.js
+++ b/src/helpers/themes.js
@@ -1,6 +1,6 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createTheme } from "@material-ui/core/styles";
 
-export const basicTheme = createMuiTheme({
+export const basicTheme = createTheme({
   shadows: ["none"],
   palette: {
     primary: {


### PR DESCRIPTION
## Description
- ```<Grid``` used the invalid ```xs``` prop, which needs to be used along with ```item```. 
    - changed the component to ```<Grid item```
- renamed ```justify``` prop of ```<Grid />``` component to ```justifyContent``` because the former has been deprecated.
- ```<Typography``` used an invalid prop ```variant=body```, edited it to :
    -  either ```variant="button"``` 
    - or removed variant, which lead to no UI changes.
- edited ```data-testID``` to ```data-testid``` . Former was an invalid prop which caused errors.
- renamed ```createMuiTheme``` function to ```createTheme``` because the former will be deprecated soon.
- ```justifyContent``` on ```<Grid />``` component had been given the invalid value ```left```, edited it to ```flex-start```.

## Related Issues
resolves #217 :   ```<Grid xs />```prop Errors

resolves #226 :   ```<Grid justify alignItems="left"``` errors

resolves #257 :   Deprecated ```createMuiTheme``` function, ```data-testid``` and ```<Typography variant="body"``` errors


## Motivation and Context
Due to the console errors, loading frontend took time and had lags.

## How Has This Been Tested?
Made sure that the frontend does not have any UI bugs, made sure by checking CSS and website design again.

## Screenshots or GIF :

Page : 

<img width="1440" alt="Screenshot 2022-04-11 at 17 29 26" src="https://user-images.githubusercontent.com/77532581/162734946-8166acea-29a8-4ca2-aa24-32e0ac31033f.png">

Console :

<img width="1434" alt="Screenshot 2022-04-11 at 17 22 08" src="https://user-images.githubusercontent.com/77532581/162736921-533aec3b-8bfc-4fb7-9ec5-2d3a68deffb9.png">



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
