### PR TITLE
wrapping tags inside chip components

### DIFF
--- a/src/components/util/CodelabCard/index.js
+++ b/src/components/util/CodelabCard/index.js
@@ -27,9 +27,7 @@ const CardComponent = ({
     const createTagArray = async() => {
       const tagSplit = tags.split("#").filter((element) => element);
       const finalTagsArray = await tagSplit.map((item) => {
-        if (item) {
           return item.trim();
-        }
       });
       setTagsArray(finalTagsArray);
     }

--- a/src/components/util/CodelabCard/index.js
+++ b/src/components/util/CodelabCard/index.js
@@ -28,7 +28,6 @@ const CardComponent = ({
       const tagSplit = tags.split("#").filter((element) => element);
       const finalTagsArray = await tagSplit.map((item) => {
         if (item) {
-          console.log(item,"this is item");
           return item.trim();
         }
       });

--- a/src/components/util/CodelabCard/index.js
+++ b/src/components/util/CodelabCard/index.js
@@ -7,6 +7,7 @@ import IconButton from "@material-ui/core/IconButton";
 import Grid from "@material-ui/core/Grid";
 import CardHeader from "@material-ui/core/CardHeader";
 import FavoriteIcon from "@material-ui/icons/Favorite";
+import { Chip } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
 import ChatIcon from "@material-ui/icons/Chat";
 import useStyles from "./styles";
@@ -21,13 +22,33 @@ const CardComponent = ({
 }) => {
   const classes = useStyles();
   const [logoPath, setLogoPath] = React.useState("");
+  const [tagsArray, setTagsArray] = React.useState([]);
+  React.useEffect(() => {
+    const createTagArray = async() => {
+      const tagSplit = tags.split("#").filter((element) => element);
+      const finalTagsArray = await tagSplit.map((item) => {
+        if (item) {
+          console.log(item,"this is item");
+          return item.trim();
+        }
+      });
+      setTagsArray(finalTagsArray);
+    }
+    createTagArray();
+  }, []);
+
   React.useEffect(() => {
     setLogoPath(org);
   }, [org]);
-
+  
   return (
     <>
-      <Card maxWidth="sm" className={classes.card} style={{ background: background }} data-testId="codelabzCard">
+      <Card
+        maxWidth="sm"
+        className={classes.card}
+        style={{ background: background }}
+        data-testId="codelabzCard"
+      >
         <CardHeader
           data-testId="codelabzCardHeader"
           className={classes.cardHeader}
@@ -42,9 +63,15 @@ const CardComponent = ({
               {logoPath ? (
                 <Grid container>
                   <Grid item className={classes.headerGrid}>
-                    <img src="/logo.jpeg" alt="logo" className={classes.logoImg} />
                     <img
-                      src={require(`../../../assets/images/${profilePic}`).default}
+                      src="/logo.jpeg"
+                      alt="logo"
+                      className={classes.logoImg}
+                    />
+                    <img
+                      src={
+                        require(`../../../assets/images/${profilePic}`).default
+                      }
                       alt=""
                       height="20rem"
                       width="20rem"
@@ -53,14 +80,19 @@ const CardComponent = ({
                   </Grid>
                 </Grid>
               ) : (
-                <img src={require(`../../../assets/images/${profilePic}`).default} alt="" className={classes.avatar} />
+                <img
+                  src={require(`../../../assets/images/${profilePic}`).default}
+                  alt=""
+                  className={classes.avatar}
+                />
               )}
             </Grid>
           }
           title={
             org ? (
               <Typography variant="body">
-                Demo Name {<span style={{ color: "#7D7C7D" }}>for</span>} ScoreLabz
+                Demo Name {<span style={{ color: "#7D7C7D" }}>for</span>}{" "}
+                ScoreLabz
               </Typography>
             ) : (
               <Typography variant="body">Demo Name</Typography>
@@ -75,21 +107,48 @@ const CardComponent = ({
           className={classes.cardContent}
           style={{ paddingBottom: "0rem" }}
         >
-          <Grid container alignItems="left" justify="flex-start" direction="column" className={classes.body}>
+          <Grid
+            container
+            alignItems="left"
+            justify="flex-start"
+            direction="column"
+            className={classes.body}
+          >
             <Grid item>
               <Typography variant="h5" gutterBottom className={classes.heading}>
                 {title}
               </Typography>
             </Grid>
-            <Grid container direction="row" justify="flex-start" alignItems="left">
-              <Typography variant="body2" color="textPrimary" className={"mr-8 " + classes.tags}>
-                {tags}
-              </Typography>
+            <Grid
+              container
+              direction="row"
+              justify="flex-start"
+              alignItems="left"
+            >
+              {tagsArray.map((tag) => {
+                return (
+                  <Chip
+                    variant="body2"
+                    color="textPrimary"
+                    className={"mr-8 " + classes.tags}
+                    label={tag}
+                    style={{ marginRight: "5px", marginBottom:"5px" }}
+                  >
+                    {tag}
+                  </Chip>
+                );
+              })}
             </Grid>
           </Grid>
         </CardContent>
         <CardActions disableSpacing className={classes.cardAction}>
-          <Grid container xs={6} justify="left" direction="row" data-testId="codelabzCardButtonGroup">
+          <Grid
+            container
+            xs={6}
+            justify="left"
+            direction="row"
+            data-testId="codelabzCardButtonGroup"
+          >
             <Grid item direction="row">
               {!org ? (
                 <Grid item style={{ height: "2rem" }}>
@@ -119,14 +178,29 @@ const CardComponent = ({
               )}
             </Grid>
           </Grid>
-          <Grid xs={6} container direction="row" justify="flex-end" alignItems="center">
+          <Grid
+            xs={6}
+            container
+            direction="row"
+            justify="flex-end"
+            alignItems="center"
+          >
             <Grid item xs={3}>
-              <Typography variant="body2" color="textSecondary" alignItems="flex-end" className={classes.readTime}>
+              <Typography
+                variant="body2"
+                color="textSecondary"
+                alignItems="flex-end"
+                className={classes.readTime}
+              >
                 10 min read
               </Typography>
             </Grid>
             <Grid item>
-              <Button variant="contained" color="primary" style={{ backgroundColor: "royalblue", margin: "16px" }}>
+              <Button
+                variant="contained"
+                color="primary"
+                style={{ backgroundColor: "royalblue", margin: "16px" }}
+              >
                 Save
               </Button>
             </Grid>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Split the tags using split() function, by passing "#" as an argument to split() function
2. passed trim elements from split() function output to another array and store that array inside tagsArray.
3. use tagarray to map tags inside chip component.


## Related Issue
fixes #267 

## Motivation and Context

- Tags should be separated properly for a better visual experience.
- Major blogs use chips to wrap tags and hence provide a good visual experience.


## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/77586067/163670436-d2eeefcb-9ee8-4518-9b92-b62d76b3be93.png)
![image](https://user-images.githubusercontent.com/77586067/163670447-2483562f-1949-446c-a340-2c0707094b87.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
