### PR TITLE
alignment issue in rightmenu of mainnavbar resolve

### DIFF
--- a/src/components/NavBar/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/MainNavbar/RightMenu.js
@@ -112,7 +112,9 @@ const RightMenu = ({ mode }) => {
         {allowDashboard && (
           <MenuItem key="setting:2">
             <Link to={"/tutorials"}>
-              <CodeOutlinedIcon /> My Tutorials
+              <Grid container direction="row" alignItems="center">
+                <CodeOutlinedIcon /> My Tutorials
+              </Grid>
             </Link>
           </MenuItem>
         )}
@@ -126,7 +128,9 @@ const RightMenu = ({ mode }) => {
           >
             <MenuItem key={`org:${-1}`} style={{ marginBottom: "4px" }}>
               <Link to={`/organization`}>
-                <SettingsOutlinedIcon /> Manage All
+                <Grid container direction="row" alignItems="center">
+                  <SettingsOutlinedIcon /> Manage All
+                </Grid>
               </Link>
             </MenuItem>
             <Divider></Divider>
@@ -141,7 +145,9 @@ const RightMenu = ({ mode }) => {
           <MenuItem key="setting:1">
             <Link to={"/profile"}>
               <div style={{ color: "#455A64" }}>
-                <PersonOutlineOutlinedIcon /> My Profile
+                <Grid container direction="row" alignItems="center">
+                  <PersonOutlineOutlinedIcon /> My Profile
+                </Grid>
               </div>
             </Link>
           </MenuItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- wrapped icons and name string in rightmenu mainnavbar inside Grid Component to provide proper horizontal alignment.

## Related Issue
#279 

## How Has This Been Tested?
On different screens using chrome inspect method

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/77586067/166099394-31c04539-71e2-465d-aba1-9c2189347f94.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
