### PR TITLE
adding social media links in organization about page

### DIFF
--- a/src/components/Organization/Orgsocial/index.js
+++ b/src/components/Organization/Orgsocial/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Box from "@material-ui/core/Box";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
@@ -9,14 +9,34 @@ import TwitterIcon from "@material-ui/icons/Twitter";
 import FacebookIcon from "@material-ui/icons/Facebook";
 import useStyles from "./styles";
 import { signInWithGoogle, signInWithProviderID } from "../../../store/actions";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useFirebase } from "react-redux-firebase";
 import { Grid } from "@material-ui/core";
 
-const Orgsocial= () => {
+const Orgsocial = () => {
   const classes = useStyles();
+
+  const CurrentOrg = useSelector(
+    ({
+      profile: {
+        data: { organizations }
+      },
+      org: {
+        general: { current }
+      }
+    }) => organizations.find(element => element.org_handle === current)
+  );
+
+  const [OrgData, setOrgData] = useState(CurrentOrg);
+
   const dispatch = useDispatch();
   const firebase = useFirebase();
+
+  const openSocialMedialLink = url => {
+    if (url) {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  };
 
   return (
     <Card className={classes.root}>
@@ -30,11 +50,14 @@ const Orgsocial= () => {
             <FacebookIcon className={classes.fb}>
               <span className="sm-text">Facebook</span>
             </FacebookIcon>
-            <Typography className={classes.text}>
-            Organization's Facebook Page
+            <Typography
+              className={classes.text}
+              onClick={() => openSocialMedialLink(OrgData.org_link_facebook)}
+            >
+              Organization's Facebook Page
             </Typography>
           </Grid>
-          
+
           <Grid
             className={classes.link}
             // onClick={() => signInWithProviderID("github")(firebase, dispatch)}
@@ -43,8 +66,11 @@ const Orgsocial= () => {
             <GitHubIcon className={classes.git}>
               <span className="sm-text">Github</span>
             </GitHubIcon>
-            <Typography className={classes.text}>
-            Organization's Github Account
+            <Typography
+              className={classes.text}
+              onClick={() => openSocialMedialLink(OrgData.org_link_facebook)}
+            >
+              Organization's Github Account
             </Typography>
           </Grid>
         </Box>
@@ -55,7 +81,10 @@ const Orgsocial= () => {
             data-testId="googleButton"
           >
             <img src={GoogleImg} alt="google" className={classes.button} />
-            <Typography className={classes.text}>
+            <Typography
+              className={classes.text}
+              onClick={() => openSocialMedialLink(OrgData.org_link_facebook)}
+            >
               Organization's Google Account
             </Typography>
           </Grid>
@@ -67,8 +96,11 @@ const Orgsocial= () => {
             <TwitterIcon className={classes.tw}>
               <span className="sm-text">Twitter</span>
             </TwitterIcon>
-            <Typography className={classes.text}>
-            Organization's Twitter Account
+            <Typography
+              className={classes.text}
+              onClick={() => openSocialMedialLink(OrgData.org_link_github)}
+            >
+              Organization's Twitter Account
             </Typography>
           </Grid>
         </Box>

--- a/src/components/Organization/Orgsocial/index.js
+++ b/src/components/Organization/Orgsocial/index.js
@@ -13,7 +13,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { useFirebase } from "react-redux-firebase";
 import { Grid } from "@material-ui/core";
 
-const Orgsocial = () => {
+const Orgsocial = props => {
+  console.log(props.toOpen);
   const classes = useStyles();
 
   const CurrentOrg = useSelector(
@@ -45,15 +46,17 @@ const Orgsocial = () => {
           <Grid
             className={classes.link}
             // onClick={() => signInWithProviderID("facebook")(firebase, dispatch)}
+            onClick={() =>
+              props.toOpen
+                ? openSocialMedialLink(OrgData.org_link_facebook)
+                : console.log("clicked")
+            }
             data-testId="facebookButton"
           >
             <FacebookIcon className={classes.fb}>
               <span className="sm-text">Facebook</span>
             </FacebookIcon>
-            <Typography
-              className={classes.text}
-              onClick={() => openSocialMedialLink(OrgData.org_link_facebook)}
-            >
+            <Typography className={classes.text}>
               Organization's Facebook Page
             </Typography>
           </Grid>
@@ -61,15 +64,17 @@ const Orgsocial = () => {
           <Grid
             className={classes.link}
             // onClick={() => signInWithProviderID("github")(firebase, dispatch)}
+            onClick={() =>
+              props.toOpen
+                ? openSocialMedialLink(OrgData.org_link_github)
+                : console.log("clicked")
+            }
             data-testId="githubButton"
           >
             <GitHubIcon className={classes.git}>
               <span className="sm-text">Github</span>
             </GitHubIcon>
-            <Typography
-              className={classes.text}
-              onClick={() => openSocialMedialLink(OrgData.org_link_facebook)}
-            >
+            <Typography className={classes.text}>
               Organization's Github Account
             </Typography>
           </Grid>
@@ -78,28 +83,32 @@ const Orgsocial = () => {
           <Grid
             className={classes.link}
             // onClick={() => signInWithGoogle()(firebase, dispatch)}
+            onClick={() =>
+              props.toOpen
+                ? openSocialMedialLink(OrgData.org_link_linkedin)
+                : console.log("clicked")
+            }
             data-testId="googleButton"
           >
             <img src={GoogleImg} alt="google" className={classes.button} />
-            <Typography
-              className={classes.text}
-              onClick={() => openSocialMedialLink(OrgData.org_link_facebook)}
-            >
+            <Typography className={classes.text}>
               Organization's Google Account
             </Typography>
           </Grid>
           <Grid
             className={classes.link}
             // onClick={() => signInWithProviderID("twitter")(firebase, dispatch)}
+            onClick={() =>
+              props.toOpen
+                ? openSocialMedialLink(OrgData.org_link_twitter)
+                : console.log("clicked")
+            }
             data-testId="twitterButton"
           >
             <TwitterIcon className={classes.tw}>
               <span className="sm-text">Twitter</span>
             </TwitterIcon>
-            <Typography
-              className={classes.text}
-              onClick={() => openSocialMedialLink(OrgData.org_link_github)}
-            >
+            <Typography className={classes.text}>
               Organization's Twitter Account
             </Typography>
           </Grid>

--- a/src/components/Organization/ViewOrganization/About.js
+++ b/src/components/Organization/ViewOrganization/About.js
@@ -2,15 +2,15 @@ import { Divider, Grid, makeStyles, Typography } from "@material-ui/core";
 import React from "react";
 import AboutUsers from "../../UserDetails/AboutUsers";
 import Orgusers from "../OrgUsers/OrgUsers";
-
-const useStyles = makeStyles((theme) => ({
+import Orgsocial from "../Orgsocial/index";
+const useStyles = makeStyles(theme => ({
   heading: {
-    fontWeight: 600,
+    fontWeight: 600
   },
   description: {
     width: "100%",
-    marginTop: 10,
-  },
+    marginTop: 10
+  }
 }));
 
 const AdminUsers = [
@@ -19,17 +19,17 @@ const AdminUsers = [
     designation: "GSoC 22'",
     avatar: {
       type: "char",
-      value: "A",
-    },
+      value: "A"
+    }
   },
   {
     name: "Sarfraz Alam",
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
-  },
+      value: "https://i.pravatar.cc/300"
+    }
+  }
 ];
 
 const ContributersUsers = [
@@ -38,25 +38,25 @@ const ContributersUsers = [
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
+      value: "https://i.pravatar.cc/300"
+    }
   },
   {
     name: "Jhanvi Thakkar",
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
+      value: "https://i.pravatar.cc/300"
+    }
   },
   {
     name: "Saksham Sharma",
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
-  },
+      value: "https://i.pravatar.cc/300"
+    }
+  }
 ];
 
 const SubscribeUsers = [
@@ -65,33 +65,33 @@ const SubscribeUsers = [
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
+      value: "https://i.pravatar.cc/300"
+    }
   },
   {
     name: "Jhanvi Thakkar",
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
+      value: "https://i.pravatar.cc/300"
+    }
   },
   {
     name: "Saksham Sharma",
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
+      value: "https://i.pravatar.cc/300"
+    }
   },
   {
     name: "Ayush Bansal",
     designation: "GSoC 22'",
     avatar: {
       type: "image",
-      value: "https://i.pravatar.cc/300",
-    },
-  },
+      value: "https://i.pravatar.cc/300"
+    }
+  }
 ];
 
 function About() {
@@ -101,8 +101,9 @@ function About() {
     <React.Fragment>
       <div
         style={{
-          marginTop: "1rem",
-        }}>
+          marginTop: "1rem"
+        }}
+      >
         <Grid container spacing={3}>
           <Grid item xs={12}>
             <Divider />
@@ -151,6 +152,14 @@ function About() {
               DataTestId="org-subscriber-list"
               isViewMore={true}
             />
+          </Grid>
+          <Grid item>
+            <Typography variant="h5" className={classes.heading}>
+              Follow us on Social Media
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Orgsocial toOpen={true}/>
           </Grid>
         </Grid>
       </div>

--- a/src/components/Organization/pages/General.js
+++ b/src/components/Organization/pages/General.js
@@ -214,6 +214,7 @@ function General() {
     CurrentOrg
   ]);
 
+  console.log(OrgData);
   return (
     <React.Fragment>
       <div data-testid="organization-general-page">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the social media handles of the organization in the about feed.
Use the existing component made for connecting social media accounts to organization account using props and conditional rendering.

## Related Issue
#475 



## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/77586067/196019360-0882fb71-f3b1-49bf-aca0-ef26a454dbf8.png)

http://g.recordit.co/WKXKnirk50.gif

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
