### PR TITLE
Making organization manager specific in the URI

### DIFF
--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -50,7 +50,6 @@ const useStyles = makeStyles(theme => ({
 const RightMenu = ({ mode, onClick }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
-
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
 
@@ -74,7 +73,7 @@ const RightMenu = ({ mode, onClick }) => {
       }
     }) => organizations
   );
-
+  
   const allowOrgs = organizations && organizations.length > 0;
 
   const orgList =
@@ -131,16 +130,31 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                  <Grid item>
-                    <Link to={`/organization`}>
-                      <Grid container spacing={3}>
-                        <Grid item>
-                          <SettingsOutlinedIcon className={classes.orgicon} />
-                        </Grid>
-                        <Grid item>Manage All</Grid>
+                {allowOrgs > 0
+                  ? organizations.map((org, i) => (
+                      <Grid item>
+                        <Link to={`/org/settings/${org.org_handle}`}>
+                          <Grid
+                            container
+                            spacing={3}
+                            direction="row"
+                            alignItems="center"
+                          >
+                            <Grid item>
+                              <Avatar
+                                src={org.org_image}
+                                className={classes.orgicon}
+                              >
+                                {avatarName(org.org_name)}
+                              </Avatar>
+                            </Grid>
+                            <Grid item>{org.org_name}</Grid>
+                          </Grid>
+                        </Link>
                       </Grid>
-                    </Link>
-                  </Grid>
+                    ))
+                  : null}
+                  
                   <Divider
                     style={{
                       marginTop: "4px",
@@ -273,16 +287,33 @@ const RightMenu = ({ mode, onClick }) => {
             </AccordionSummary>
             <AccordionDetails>
               <Grid container direction="column" spacing={1}>
-                <Grid item>
-                  <Link to={`/organization`}>
-                    <Grid container spacing={3}>
+
+                {/* Issue490: We will be connecting organizations to their settings page here*/}
+              {allowOrgs > 0
+                  ? organizations.map((org, i) => (
                       <Grid item>
-                        <SettingsOutlinedIcon className={classes.orgicon} />
+                        <Link to={`/org/settings/${org.org_handle}`}>
+                          <Grid
+                            container
+                            spacing={3}
+                            direction="row"
+                            alignItems="center"
+                          >
+                            <Grid item>
+                              <Avatar
+                                src={org.org_image}
+                                className={classes.orgicon}
+                              >
+                                {avatarName(org.org_name)}
+                              </Avatar>
+                            </Grid>
+                            <Grid item>{org.org_name}</Grid>
+                          </Grid>
+                        </Link>
                       </Grid>
-                      <Grid item>Manage All</Grid>
-                    </Grid>
-                  </Link>
-                </Grid>
+                    ))
+                  : null}
+               
                 <Divider
                   style={{
                     marginTop: "4px",

--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -51,6 +51,7 @@ const RightMenu = ({ mode, onClick }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
   const [anchorEl, setAnchorEl] = React.useState(null);
+
   const open = Boolean(anchorEl);
 
   const handleClick = event => {
@@ -65,6 +66,15 @@ const RightMenu = ({ mode, onClick }) => {
   const dispatch = useDispatch();
   const profile = useSelector(({ firebase }) => firebase.profile);
   const acronym = avatarName(profile.displayName);
+
+  //Taking out the current organization handle of the user
+  const currentOrg = useSelector(
+    ({
+      org:{
+        general:{current}
+      }
+    })=>current
+    );
 
   const organizations = useSelector(
     ({
@@ -130,31 +140,16 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                {allowOrgs > 0
-                  ? organizations.map((org, i) => (
-                      <Grid item>
-                        <Link to={`/org/settings/${org.org_handle}`}>
-                          <Grid
-                            container
-                            spacing={3}
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <Avatar
-                                src={org.org_image}
-                                className={classes.orgicon}
-                              >
-                                {avatarName(org.org_name)}
-                              </Avatar>
-                            </Grid>
-                            <Grid item>{org.org_name}</Grid>
-                          </Grid>
-                        </Link>
+                <Grid item>
+                    <Link to={`/org/settings/${currentOrg}`}>
+                      <Grid container spacing={3}>
+                        <Grid item>
+                          <SettingsOutlinedIcon className={classes.orgicon} />
+                        </Grid>
+                        <Grid item>Manage All</Grid>
                       </Grid>
-                    ))
-                  : null}
-                  
+                    </Link>
+                  </Grid>
                   <Divider
                     style={{
                       marginTop: "4px",
@@ -289,30 +284,16 @@ const RightMenu = ({ mode, onClick }) => {
               <Grid container direction="column" spacing={1}>
 
                 {/* Issue490: We will be connecting organizations to their settings page here*/}
-              {allowOrgs > 0
-                  ? organizations.map((org, i) => (
-                      <Grid item>
-                        <Link to={`/org/settings/${org.org_handle}`}>
-                          <Grid
-                            container
-                            spacing={3}
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <Avatar
-                                src={org.org_image}
-                                className={classes.orgicon}
-                              >
-                                {avatarName(org.org_name)}
-                              </Avatar>
-                            </Grid>
-                            <Grid item>{org.org_name}</Grid>
-                          </Grid>
-                        </Link>
+                <Grid item>
+                    <Link to={`/org/settings/${currentOrg}`}>
+                      <Grid container spacing={3}>
+                        <Grid item>
+                          <SettingsOutlinedIcon className={classes.orgicon} />
+                        </Grid>
+                        <Grid item>Manage All</Grid>
                       </Grid>
-                    ))
-                  : null}
+                    </Link>
+                  </Grid>
                
                 <Divider
                   style={{

--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -76,6 +76,9 @@ const RightMenu = ({ mode, onClick }) => {
     })=>current
     );
 
+    //Check if this current user is attached to some organization
+    const isOrgPresent = currentOrg == null ? false : true;
+  
   const organizations = useSelector(
     ({
       profile: {
@@ -140,7 +143,7 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                <Grid item>
+                {isOrgPresent && <Grid item>
                     <Link to={`/org/settings/${currentOrg}`}>
                       <Grid container spacing={3}>
                         <Grid item>
@@ -149,7 +152,7 @@ const RightMenu = ({ mode, onClick }) => {
                         <Grid item>Manage All</Grid>
                       </Grid>
                     </Link>
-                  </Grid>
+                  </Grid>}
                   <Divider
                     style={{
                       marginTop: "4px",
@@ -284,7 +287,7 @@ const RightMenu = ({ mode, onClick }) => {
               <Grid container direction="column" spacing={1}>
 
                 {/* Issue490: We will be connecting organizations to their settings page here*/}
-                <Grid item>
+                {isOrgPresent && <Grid item>
                     <Link to={`/org/settings/${currentOrg}`}>
                       <Grid container spacing={3}>
                         <Grid item>
@@ -293,7 +296,7 @@ const RightMenu = ({ mode, onClick }) => {
                         <Grid item>Manage All</Grid>
                       </Grid>
                     </Link>
-                  </Grid>
+                  </Grid>}
                
                 <Divider
                   style={{

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -8,6 +8,7 @@ import Org from "./../../assets/images/org.svg";
 import Profile from "./../../assets/images/profile.svg";
 import Bookmark from "./../../assets/images/bookmark.svg";
 import Logout from "./../../assets/images/logout.svg";
+import {useSelector } from "react-redux";
 import Tutorials from "./../../assets/images/tutorial.svg";
 import MyFeed from "./../../assets/images/MyFeed.svg";
 import { signOut } from "../../store/actions";
@@ -43,6 +44,15 @@ const SideBar = ({
   const dispatch = useDispatch();
   const allowDashboard = useAllowDashboard();
 
+    //Taking out the current organization handle of the user
+    const currentOrg = useSelector(
+      ({
+        org:{
+          general:{current}
+        }
+      })=>current
+      );
+
   const defaultMenu = [
     {
       name: "Home",
@@ -61,7 +71,7 @@ const SideBar = ({
     {
       name: "Organizations",
       img: Org,
-      link: "/organization"
+      link: `/org/settings/${currentOrg}`
     },
     {
       name: "My Feed",

--- a/src/routes.js
+++ b/src/routes.js
@@ -124,9 +124,10 @@ const Routes = () => {
             path={"/profile"}
             component={UserIsAllowedUserDashboard(Profile)}
           />
+         
           <Route
             exact
-            path={"/organization"}
+            path={"/org/settings/:handle"}
             component={UserIsAllowOrgManager(Organization)}
           />
           <Route


### PR DESCRIPTION
Making organization manager specific in the URI

## Description
Each Organization will be having its specific settings page at /org/settings/org_handle.So for this we have shifted organization settings route from /organiation -> /org/settings/:orgid

## Related Issue
#490.

## Motivation and Context
This will enable each organization to have it's own settings page at their specific url.

## How Has This Been Tested?
Screenshots have been attached showing organization settings route at  /org/settings/:orgid.

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/66011090/202163396-41e7acd5-22b9-4647-96ca-3a2b8d6f079a.png)
![image](https://user-images.githubusercontent.com/66011090/202163440-f2390ef0-a7e5-4dcf-aaa1-8c1bd106dec6.png)

## Types of changes
 [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
[x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
