### PR TITLE
Implement Switching Organizations in the “Switch Account Card”

### DIFF
--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect} from "react";
 import { useFirebase } from "react-redux-firebase";
 import { signOut } from "../../../../store/actions";
 import Avatar from "@material-ui/core/Avatar";
@@ -10,7 +10,7 @@ import CodeOutlinedIcon from "@material-ui/icons/CodeOutlined";
 import ExitToAppOutlinedIcon from "@material-ui/icons/ExitToAppOutlined";
 import PersonOutlineOutlinedIcon from "@material-ui/icons/PersonOutlineOutlined";
 import { avatarName } from "../../../../helpers/avatarName";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import MenuItem from "@material-ui/core/MenuItem";
 import Grid from "@material-ui/core/Grid";
 import Menu from "@material-ui/core/Menu";
@@ -27,6 +27,7 @@ import {
 import { useTheme } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+
 
 const useStyles = makeStyles(theme => ({
   menu: {
@@ -51,9 +52,16 @@ const RightMenu = ({ mode, onClick }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
   const [anchorEl, setAnchorEl] = React.useState(null);
-
+  const {pathname} = useLocation();
   const open = Boolean(anchorEl);
 
+  //This will be responsible for closing the rightMenu automatically when route Changes 
+  useEffect(() => {
+    setAnchorEl(null); 
+  }, [ pathname ]);
+ 
+  
+  console.log("i am open ", open)
   const handleClick = event => {
     setAnchorEl(event.currentTarget);
   };
@@ -61,6 +69,7 @@ const RightMenu = ({ mode, onClick }) => {
   const handleClose = () => {
     setAnchorEl(null);
   };
+
   const allowDashboard = useAllowDashboard();
   const firebase = useFirebase();
   const dispatch = useDispatch();
@@ -78,6 +87,7 @@ const RightMenu = ({ mode, onClick }) => {
 
     //Check if this current user is attached to some organization
     const isOrgPresent = currentOrg == null ? false : true;
+   
   
   const organizations = useSelector(
     ({

--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -50,7 +50,6 @@ const useStyles = makeStyles(theme => ({
 const RightMenu = ({ mode, onClick }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
-
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
 
@@ -74,7 +73,7 @@ const RightMenu = ({ mode, onClick }) => {
       }
     }) => organizations
   );
-
+  
   const allowOrgs = organizations && organizations.length > 0;
 
   const orgList =
@@ -131,16 +130,31 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                  <Grid item>
-                    <Link to={`/organization`}>
-                      <Grid container spacing={3}>
-                        <Grid item>
-                          <SettingsOutlinedIcon className={classes.orgicon} />
-                        </Grid>
-                        <Grid item>Manage All</Grid>
+                {allowOrgs > 0
+                  ? organizations.map((org, i) => (
+                      <Grid item>
+                        <Link to={`/org/settings/${org.org_handle}`}>
+                          <Grid
+                            container
+                            spacing={3}
+                            direction="row"
+                            alignItems="center"
+                          >
+                            <Grid item>
+                              <Avatar
+                                src={org.org_image}
+                                className={classes.orgicon}
+                              >
+                                {avatarName(org.org_name)}
+                              </Avatar>
+                            </Grid>
+                            <Grid item>{org.org_name}</Grid>
+                          </Grid>
+                        </Link>
                       </Grid>
-                    </Link>
-                  </Grid>
+                    ))
+                  : null}
+                  
                   <Divider
                     style={{
                       marginTop: "4px",
@@ -273,16 +287,33 @@ const RightMenu = ({ mode, onClick }) => {
             </AccordionSummary>
             <AccordionDetails>
               <Grid container direction="column" spacing={1}>
-                <Grid item>
-                  <Link to={`/organization`}>
-                    <Grid container spacing={3}>
+
+                {/* Issue490: We will be connecting organizations to their settings page here*/}
+              {allowOrgs > 0
+                  ? organizations.map((org, i) => (
                       <Grid item>
-                        <SettingsOutlinedIcon className={classes.orgicon} />
+                        <Link to={`/org/settings/${org.org_handle}`}>
+                          <Grid
+                            container
+                            spacing={3}
+                            direction="row"
+                            alignItems="center"
+                          >
+                            <Grid item>
+                              <Avatar
+                                src={org.org_image}
+                                className={classes.orgicon}
+                              >
+                                {avatarName(org.org_name)}
+                              </Avatar>
+                            </Grid>
+                            <Grid item>{org.org_name}</Grid>
+                          </Grid>
+                        </Link>
                       </Grid>
-                      <Grid item>Manage All</Grid>
-                    </Grid>
-                  </Link>
-                </Grid>
+                    ))
+                  : null}
+               
                 <Divider
                   style={{
                     marginTop: "4px",

--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -60,8 +60,6 @@ const RightMenu = ({ mode, onClick }) => {
     setAnchorEl(null); 
   }, [ pathname ]);
  
-  
-  console.log("i am open ", open)
   const handleClick = event => {
     setAnchorEl(event.currentTarget);
   };

--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -51,6 +51,7 @@ const RightMenu = ({ mode, onClick }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
   const [anchorEl, setAnchorEl] = React.useState(null);
+
   const open = Boolean(anchorEl);
 
   const handleClick = event => {
@@ -65,6 +66,15 @@ const RightMenu = ({ mode, onClick }) => {
   const dispatch = useDispatch();
   const profile = useSelector(({ firebase }) => firebase.profile);
   const acronym = avatarName(profile.displayName);
+
+  //Taking out the current organization handle of the user
+  const currentOrg = useSelector(
+    ({
+      org:{
+        general:{current}
+      }
+    })=>current
+    );
 
   const organizations = useSelector(
     ({
@@ -130,31 +140,16 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                {allowOrgs > 0
-                  ? organizations.map((org, i) => (
-                      <Grid item>
-                        <Link to={`/org/settings/${org.org_handle}`}>
-                          <Grid
-                            container
-                            spacing={3}
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <Avatar
-                                src={org.org_image}
-                                className={classes.orgicon}
-                              >
-                                {avatarName(org.org_name)}
-                              </Avatar>
-                            </Grid>
-                            <Grid item>{org.org_name}</Grid>
-                          </Grid>
-                        </Link>
+                <Grid item>
+                    <Link to={`/org/settings/${currentOrg}`}>
+                      <Grid container spacing={3}>
+                        <Grid item>
+                          <SettingsOutlinedIcon className={classes.orgicon} />
+                        </Grid>
+                        <Grid item>Manage All</Grid>
                       </Grid>
-                    ))
-                  : null}
-                  
+                    </Link>
+                  </Grid>
                   <Divider
                     style={{
                       marginTop: "4px",
@@ -289,30 +284,16 @@ const RightMenu = ({ mode, onClick }) => {
               <Grid container direction="column" spacing={1}>
 
                 {/* Issue490: We will be connecting organizations to their settings page here*/}
-              {allowOrgs > 0
-                  ? organizations.map((org, i) => (
-                      <Grid item>
-                        <Link to={`/org/settings/${org.org_handle}`}>
-                          <Grid
-                            container
-                            spacing={3}
-                            direction="row"
-                            alignItems="center"
-                          >
-                            <Grid item>
-                              <Avatar
-                                src={org.org_image}
-                                className={classes.orgicon}
-                              >
-                                {avatarName(org.org_name)}
-                              </Avatar>
-                            </Grid>
-                            <Grid item>{org.org_name}</Grid>
-                          </Grid>
-                        </Link>
+                <Grid item>
+                    <Link to={`/org/settings/${currentOrg}`}>
+                      <Grid container spacing={3}>
+                        <Grid item>
+                          <SettingsOutlinedIcon className={classes.orgicon} />
+                        </Grid>
+                        <Grid item>Manage All</Grid>
                       </Grid>
-                    ))
-                  : null}
+                    </Link>
+                  </Grid>
                
                 <Divider
                   style={{

--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -76,6 +76,9 @@ const RightMenu = ({ mode, onClick }) => {
     })=>current
     );
 
+    //Check if this current user is attached to some organization
+    const isOrgPresent = currentOrg == null ? false : true;
+  
   const organizations = useSelector(
     ({
       profile: {
@@ -140,7 +143,7 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                <Grid item>
+                {isOrgPresent && <Grid item>
                     <Link to={`/org/settings/${currentOrg}`}>
                       <Grid container spacing={3}>
                         <Grid item>
@@ -149,7 +152,7 @@ const RightMenu = ({ mode, onClick }) => {
                         <Grid item>Manage All</Grid>
                       </Grid>
                     </Link>
-                  </Grid>
+                  </Grid>}
                   <Divider
                     style={{
                       marginTop: "4px",
@@ -284,7 +287,7 @@ const RightMenu = ({ mode, onClick }) => {
               <Grid container direction="column" spacing={1}>
 
                 {/* Issue490: We will be connecting organizations to their settings page here*/}
-                <Grid item>
+                {isOrgPresent && <Grid item>
                     <Link to={`/org/settings/${currentOrg}`}>
                       <Grid container spacing={3}>
                         <Grid item>
@@ -293,7 +296,7 @@ const RightMenu = ({ mode, onClick }) => {
                         <Grid item>Manage All</Grid>
                       </Grid>
                     </Link>
-                  </Grid>
+                  </Grid>}
                
                 <Divider
                   style={{

--- a/src/components/Organization/index.js
+++ b/src/components/Organization/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import {getUserProfileData} from './../../store/actions';
 import OrgSidebar from "./OrgSidebar/orgSidebar";
 import { useMediaQuery } from "react-responsive";
 import Button from "@material-ui/core/Button";
@@ -18,8 +19,13 @@ import Socialmedia from "./pages/Socialmedia";
 import { useDispatch, useSelector } from "react-redux";
 import { useFirebase, useFirestore } from "react-redux-firebase";
 import { unPublishOrganization } from "../../store/actions";
+import { useParams } from "react-router-dom";
 
 const Organizations = () => {
+
+  //Set All the organisations for this user
+  const [organisations, setOrganisations] = useState([]);
+
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [SettingsMenu, setSettingsMenu] = useState(1);
   const classes = useStyles();
@@ -42,7 +48,7 @@ const Organizations = () => {
   );
 
   const orgs = useSelector(
-    ({
+ ({
       profile: {
         data: { organizations }
       }
@@ -66,6 +72,12 @@ const Organizations = () => {
     );
   };
 
+  
+  //Firstly I have to find the details of the current user
+  const profileData = useSelector(({firebase})=>firebase.profile);
+  //Then I will fetch the organisations from the document of the current user
+  const orgsOfUser = profileData.organizations;
+
   return (
     <Container maxWidth="xl">
       <Grid container className={classes.root} direction="column">
@@ -73,7 +85,7 @@ const Organizations = () => {
           <SwitchAccount
             Heading="Switch Account"
             name={currentOrgData.org_handle}
-            secondaryMail=""
+            userOrgs = {orgsOfUser}
             avatar={{
               value: currentOrgData.org_image
             }}

--- a/src/components/Profile/SwitchAccount/SwitchAccount.js
+++ b/src/components/Profile/SwitchAccount/SwitchAccount.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React,{useState} from "react";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
@@ -9,6 +9,10 @@ import FormControl from "@material-ui/core/FormControl";
 import Button from "@material-ui/core/Button";
 import NativeSelect from "@material-ui/core/NativeSelect";
 import { Grid } from "@material-ui/core";
+import InputLabel from '@material-ui/core/InputLabel';
+import { Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import {
   createTheme,
   responsiveFontSizes,
@@ -75,24 +79,33 @@ const useStyles = makeStyles(theme => ({
 export default function SwitchAccount({
   avatar,
   name,
-  secondaryMail,
+  userOrgs,
   buttonClick,
   buttonText
 }) {
+
+  //Getting the details of all organizations submitted by current User
+  const organizations = useSelector(
+    ({
+      profile: {
+        data: { organizations }
+      }
+    }) => organizations
+  );
+  //This will be used to move on the organization page based upon the selection in dropdown
+  let history = useHistory();
+ 
   const classes = useStyles();
   let theme = createTheme();
   theme = responsiveFontSizes(theme);
-  const [state, setState] = React.useState({
-    email: "",
-    name: ""
-  });
+  const [organisation, setOrganisation] = useState("");
 
   const handleChange = event => {
     const name = event.target.name;
-    setState({
-      ...state,
-      [name]: event.target.value
-    });
+    console.log("Event target is", name, event.target.value);
+    setOrganisation(event.target.value)
+    //This will take you to the selected organiztion home page
+    history.push(`/org/${ event.target.value}`);
   };
 
   return (
@@ -119,20 +132,28 @@ export default function SwitchAccount({
               <IconButton aria-label="share">
                 <SwapHorizIcon />
               </IconButton>
+
+              <div>
               <FormControl className={classes.formControl}>
-                <NativeSelect
-                  className={classes.selectEmpty}
-                  value={state.age}
-                  name="age"
-                  onChange={handleChange}
-                  inputProps={{ "aria-label": "age" }}
-                >
-                  <option value="" disabled color="primary">
-                    Switch to another account
-                  </option>
-                  <option value={10}>{secondaryMail}</option>
-                </NativeSelect>
-              </FormControl>
+        <NativeSelect
+          className={classes.selectEmpty}
+          value={organisation}
+          name="organisation"
+          onChange={handleChange}
+          inputProps={{ 'aria-label': 'Organizations' }}
+        
+        >
+
+          {/* dropdown options for switching organisations */}
+           <option value="">Organisations</option>
+           {
+            userOrgs.map((org)=>(
+             <option value={org}>{org}</option>
+            ))
+           }
+        </NativeSelect>
+      </FormControl>
+      </div>
             </div>
           </div>
         </ThemeProvider>

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -8,6 +8,7 @@ import Org from "./../../assets/images/org.svg";
 import Profile from "./../../assets/images/profile.svg";
 import Bookmark from "./../../assets/images/bookmark.svg";
 import Logout from "./../../assets/images/logout.svg";
+import {useSelector } from "react-redux";
 import Tutorials from "./../../assets/images/tutorial.svg";
 import MyFeed from "./../../assets/images/MyFeed.svg";
 import { signOut } from "../../store/actions";
@@ -43,6 +44,15 @@ const SideBar = ({
   const dispatch = useDispatch();
   const allowDashboard = useAllowDashboard();
 
+    //Taking out the current organization handle of the user
+    const currentOrg = useSelector(
+      ({
+        org:{
+          general:{current}
+        }
+      })=>current
+      );
+
   const defaultMenu = [
     {
       name: "Home",
@@ -61,7 +71,7 @@ const SideBar = ({
     {
       name: "Organizations",
       img: Org,
-      link: "/organization"
+      link: `/org/settings/${currentOrg}`
     },
     {
       name: "My Feed",

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,9 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-*{
+/* *{
     box-sizing:border-box !important
-}
+} */
 
 ::-webkit-scrollbar {
     width: 5px;

--- a/src/routes.js
+++ b/src/routes.js
@@ -124,9 +124,10 @@ const Routes = () => {
             path={"/profile"}
             component={UserIsAllowedUserDashboard(Profile)}
           />
+         
           <Route
             exact
-            path={"/organization"}
+            path={"/org/settings/:handle"}
             component={UserIsAllowOrgManager(Organization)}
           />
           <Route


### PR DESCRIPTION
Implement Switching Organizations in the “Switch Account Card”

## Description
Users can switch to different organizations they have created using this dropdown.

## Related Issue
#454

## Motivation and Context
This will allow users to switch organizations easily.

## How Has This Been Tested?
Screenshots have been attached here.

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/66011090/202411009-d47a1c0b-86ed-4ad6-b75e-21a0f922eabf.png)
![Screenshot (1)](https://user-images.githubusercontent.com/66011090/202411578-44df4adf-a743-4900-91da-0fb23b7b5dc9.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

