### PR TITLE
bug :hamburger menu 

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,7 +17,6 @@
     "functions": {
       "port": 5001,
       "host": "127.0.0.1"
-
     },
     "ui": {
       "enabled": true
@@ -25,7 +24,6 @@
     "auth": {
       "port": 9099,
       "host": "127.0.0.1"
-
     },
     "firestore": {
       "port": 8080,
@@ -46,7 +44,8 @@
     "storage": {
       "port": 9199,
       "host": "127.0.0.1"
-    }
+    },
+    "singleProjectMode": true
   },
   "storage": {
     "rules": "storage.rules"

--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,7 @@
     "functions": {
       "port": 5001,
       "host": "127.0.0.1"
+
     },
     "ui": {
       "enabled": true
@@ -24,6 +25,7 @@
     "auth": {
       "port": 9099,
       "host": "127.0.0.1"
+
     },
     "firestore": {
       "port": 8080,
@@ -44,8 +46,7 @@
     "storage": {
       "port": 9199,
       "host": "127.0.0.1"
-    },
-    "singleProjectMode": true
+    }
   },
   "storage": {
     "rules": "storage.rules"

--- a/src/components/HomePage/styles.js
+++ b/src/components/HomePage/styles.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
     margin: "0 1rem 2rem 1rem",
     height: "100%",
     flexDirection: "column",
-    [theme.breakpoints.down(750)]: {
+    [theme.breakpoints.down(960)]: {
       display: "none"
     },
     maxWidth: "300px"

--- a/src/components/NavBar/new/MainNavbar/index.js
+++ b/src/components/NavBar/new/MainNavbar/index.js
@@ -134,11 +134,12 @@ function MainNavbar() {
             </Grid>
           </Grid>
         </Grid>
-        {windowSize.width <= 750 && (
+        {windowSize.width <= 960 && (
           <SideBar
             open={openMenu}
             toggleSlider={toggleSlider}
             notification={notification}
+            drawWidth = {960}
           />
         )}
       </nav>

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -35,6 +35,7 @@ const SideBar = ({
   toggleSlider,
   notification,
   menuItems,
+  drawWidth,
   value,
   onStateChange,
   children
@@ -101,7 +102,7 @@ const SideBar = ({
   const classes = useStyles();
   return (
     <>
-      {windowSize.width <= 750 ? (
+      {windowSize.width <= (drawWidth || 750) ? (
         <Drawer
           closable="true"
           open={open}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Now the SideBar component has a new prop drawWidth , it will now help in making the sidenav appear in different scrren width, yet default is set to 750px.
At home page the meu bar turns to hambureger menu below 960px and the main content has more space.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#495 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The menu takes almost half the screen on smaller screen , 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):
https://user-images.githubusercontent.com/95560057/203826357-b035ea9a-0bfe-4fb5-ae9e-0e093f54f923.mp4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
