### PR TITLE
Implement Switching Organizations in the “Switch Account Card” and Making Right Menu close By itself on Route Change

### DIFF
--- a/src/components/NavBar/new/MainNavbar/RightMenu.js
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React,{useEffect} from "react";
 import { useFirebase } from "react-redux-firebase";
 import { signOut } from "../../../../store/actions";
 import Avatar from "@material-ui/core/Avatar";
@@ -10,7 +10,7 @@ import CodeOutlinedIcon from "@material-ui/icons/CodeOutlined";
 import ExitToAppOutlinedIcon from "@material-ui/icons/ExitToAppOutlined";
 import PersonOutlineOutlinedIcon from "@material-ui/icons/PersonOutlineOutlined";
 import { avatarName } from "../../../../helpers/avatarName";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import MenuItem from "@material-ui/core/MenuItem";
 import Grid from "@material-ui/core/Grid";
 import Menu from "@material-ui/core/Menu";
@@ -50,9 +50,14 @@ const useStyles = makeStyles(theme => ({
 const RightMenu = ({ mode, onClick }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
+  const {pathname} = useLocation();
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const open = Boolean(anchorEl);
+  //This will be responsible for closing the rightMenu automatically when route Changes 
+  useEffect(() => {
+    setAnchorEl(null);
+  }, [pathname]);
 
   const handleClick = event => {
     setAnchorEl(event.currentTarget);

--- a/src/components/Organization/index.js
+++ b/src/components/Organization/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import {getUserProfileData} from './../../store/actions';
 import OrgSidebar from "./OrgSidebar/orgSidebar";
 import { useMediaQuery } from "react-responsive";
 import Button from "@material-ui/core/Button";
@@ -22,8 +23,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useFirebase, useFirestore } from "react-redux-firebase";
 import { unPublishOrganization } from "../../store/actions";
 import useWindowSize from "../../helpers/customHooks/useWindowSize";
+import { useParams } from "react-router-dom";
 
 const Organizations = () => {
+   //Set All the organisations for this user
+   const [organisations, setOrganisations] = useState([]);
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [SettingsMenu, setSettingsMenu] = useState(1);
   const classes = useStyles();
@@ -83,6 +87,11 @@ const Organizations = () => {
     );
   };
 
+  //Firstly we have to find the details of the current user
+  const profileData = useSelector(({ firebase }) => firebase.profile);
+  //Then we will fetch the organisations from the document of the current user
+  const orgsOfUser = profileData.organizations;
+
   return (
     <Container maxWidth="xl">
       <Grid container className={classes.root} direction="column">
@@ -90,7 +99,7 @@ const Organizations = () => {
           <SwitchAccount
             Heading="Switch Account"
             name={currentOrgData.org_handle}
-            secondaryMail=""
+            userOrgs = {orgsOfUser}
             avatar={{
               value: currentOrgData.org_image
             }}

--- a/src/components/Profile/SwitchAccount/SwitchAccount.js
+++ b/src/components/Profile/SwitchAccount/SwitchAccount.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React,{useState} from "react";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
@@ -9,6 +9,10 @@ import FormControl from "@material-ui/core/FormControl";
 import Button from "@material-ui/core/Button";
 import NativeSelect from "@material-ui/core/NativeSelect";
 import { Grid } from "@material-ui/core";
+import InputLabel from '@material-ui/core/InputLabel';
+import { Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import {
   createTheme,
   responsiveFontSizes,
@@ -75,24 +79,31 @@ const useStyles = makeStyles(theme => ({
 export default function SwitchAccount({
   avatar,
   name,
-  secondaryMail,
+  userOrgs,
   buttonClick,
   buttonText
 }) {
+  //Getting the details of all organizations submitted by current User
+  const organizations = useSelector(
+    ({
+      profile: {
+        data: { organizations }
+      }
+    }) => organizations
+  );
+  //This will be used to move on the organization page based upon the selection in dropdown
+  let history = useHistory();
+
   const classes = useStyles();
   let theme = createTheme();
   theme = responsiveFontSizes(theme);
-  const [state, setState] = React.useState({
-    email: "",
-    name: ""
-  });
+  const [organisation, setOrganisation] = useState("");
 
   const handleChange = event => {
     const name = event.target.name;
-    setState({
-      ...state,
-      [name]: event.target.value
-    });
+    setOrganisation(event.target.value)
+    //This will take you to the selected organiztion home page
+    history.push(`/org/${ event.target.value}`);
   };
 
   return (
@@ -119,20 +130,28 @@ export default function SwitchAccount({
               <IconButton aria-label="share">
                 <SwapHorizIcon />
               </IconButton>
+
+              <div>
               <FormControl className={classes.formControl}>
-                <NativeSelect
-                  className={classes.selectEmpty}
-                  value={state.age}
-                  name="age"
-                  onChange={handleChange}
-                  inputProps={{ "aria-label": "age" }}
-                >
-                  <option value="" disabled color="primary">
-                    Switch to another account
-                  </option>
-                  <option value={10}>{secondaryMail}</option>
-                </NativeSelect>
+              <NativeSelect
+          className={classes.selectEmpty}
+          value={organisation}
+          name="organisation"
+          onChange={handleChange}
+          inputProps={{ 'aria-label': 'Organizations' }}
+
+        >
+
+          {/* dropdown options for switching organisations */}
+           <option value="">Organisations</option>
+           {
+            userOrgs.map((org)=>(
+             <option value={org}>{org}</option>
+            ))
+           }
+        </NativeSelect>
               </FormControl>
+              </div>
             </div>
           </div>
         </ThemeProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,9 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-*{
+/* *{
     box-sizing:border-box !important
-}
+} */
 
 ::-webkit-scrollbar {
     width: 5px;


### PR DESCRIPTION
Implement Switching Organizations in the “Switch Account Card” and Making Right Menu close By itself on Route Change

## Description
Users can switch to different organizations they have created using this dropdown. The right Menu will get closed by itself when we reach the desired page.

## Related Issue
#454

## Motivation and Context
This will allow users to switch organizations easily. For more clarity on the problem these are the attachments:
https://drive.google.com/file/d/1EHuDACLD6u-H9ezbW3w8wg2GS1Qgw3zt/view?usp=share_link
https://drive.google.com/file/d/1ZENZkLEOOrgvMAmXPLAFgHlwYFhbM8vl/view?usp=share_link

## How Has This Been Tested?
The videos and screenshots are attached here:
https://drive.google.com/file/d/1MU8aF5mbmEdczmkb8cG1B5NawblXGS9M/view?usp=share_link
![image](https://user-images.githubusercontent.com/66011090/205144263-36fdbe4a-de26-421d-b726-c4f06b87908a.png)
![Screenshot (9)](https://user-images.githubusercontent.com/66011090/205144371-234f4142-0983-4dbd-a665-5c4179c62c9c.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
