### PR TITLE
Improved the UI of Organization's Password Page

### DIFF
--- a/src/components/Organization/pages/Passwords.js
+++ b/src/components/Organization/pages/Passwords.js
@@ -44,14 +44,14 @@ const useStyles = makeStyles(theme => ({
     borderRadius: "10px",
     padding: "10px"
   },
-  responsiveHeading:{
+  heading:{
     fontSize: "1.5rem",
     fontWeight: 100,
     [theme.breakpoints.between('xs', 'sm')]: {
       textAlign: 'center'
     }
   },
-  responsiveInput:{
+  inputContainer:{
     [theme.breakpoints.between('xs', 'sm')]: {
       textAlign: 'center'
     },
@@ -71,24 +71,24 @@ function Passwords() {
         data-testid="organization-passwords-page"
       >
         <Grid item xs={12}>
-          <Typography className={classes.responsiveHeading}>Passwords</Typography>
+          <Typography className={classes.heading}>Passwords</Typography>
         </Grid>
-        <Grid className={classes.responsiveInput} item xs={12}>
+        <Grid className={classes.inputContainer} item xs={12}>
           <Typography>Old Password</Typography>
           <InputBase className={classes.input} placeholder="Old Password" />
         </Grid>
-        <Grid className={classes.responsiveInput} item xs={12}>
+        <Grid className={classes.inputContainer} item xs={12}>
           <Typography>New Password</Typography>
           <InputBase className={classes.input} placeholder="New Password" />
         </Grid>
-        <Grid className={classes.responsiveInput} item xs={12}>
+        <Grid className={classes.inputContainer} item xs={12}>
           <Typography>Confirm new password</Typography>
           <InputBase
             className={classes.input}
             placeholder="Confirm new password"
           />
         </Grid>
-        <Grid className={classes.responsiveInput} item xs={12}>
+        <Grid className={classes.inputContainer} item xs={12}>
           <Button className={classes.button}>Update Password</Button>
         </Grid>
       </Grid>

--- a/src/components/Organization/pages/Passwords.js
+++ b/src/components/Organization/pages/Passwords.js
@@ -9,23 +9,52 @@ import {
 
 const useStyles = makeStyles(theme => ({
   root: {
-    padding: 20
-  },
-  heading: {
-    fontSize: "1.5rem",
-    fontWeight: 100
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: "10px",
+    marginTop: '15px',
+    display: 'flex',
+    alignContent: 'stretch',
+    justifyContent: 'space-evenly',
+    width: '98%',
+    marginBottom: '20px',
+    [theme.breakpoints.between('xs', 'sm')]:{
+      marginLeft:'10px'
+    },
+
   },
   input: {
     padding: 10,
     border: "1px solid #ccc",
     borderRadius: "10px",
     marginTop: "10px",
-    width: "50%"
+    width: "50%",
+    "&:hover": {backgroundColor: '#F5F5F5'},
+    [theme.breakpoints.between('xs', 'sm')]:{
+      width:'100%',
+    },
+    [theme.breakpoints.between('sm', 'md')]:{
+      width:'70%',
+    },
+    [theme.breakpoints.between('md', 'lg')]:{
+      width:'35%',
+    }
   },
   button: {
     border: "1px solid #ccc",
     borderRadius: "10px",
     padding: "10px"
+  },
+  responsiveHeading:{
+    fontSize: "1.5rem",
+    fontWeight: 100,
+    [theme.breakpoints.between('xs', 'sm')]: {
+      textAlign: 'center'
+    }
+  },
+  responsiveInput:{
+    [theme.breakpoints.between('xs', 'sm')]: {
+      textAlign: 'center'
+    },
   }
 }));
 
@@ -42,24 +71,24 @@ function Passwords() {
         data-testid="organization-passwords-page"
       >
         <Grid item xs={12}>
-          <Typography className={classes.heading}>Passwords</Typography>
+          <Typography className={classes.responsiveHeading}>Passwords</Typography>
         </Grid>
-        <Grid item xs={12}>
+        <Grid className={classes.responsiveInput} item xs={12}>
           <Typography>Old Password</Typography>
           <InputBase className={classes.input} placeholder="Old Password" />
         </Grid>
-        <Grid item xs={12}>
+        <Grid className={classes.responsiveInput} item xs={12}>
           <Typography>New Password</Typography>
           <InputBase className={classes.input} placeholder="New Password" />
         </Grid>
-        <Grid item xs={12}>
+        <Grid className={classes.responsiveInput} item xs={12}>
           <Typography>Confirm new password</Typography>
           <InputBase
             className={classes.input}
             placeholder="Confirm new password"
           />
         </Grid>
-        <Grid item xs={12}>
+        <Grid className={classes.responsiveInput} item xs={12}>
           <Button className={classes.button}>Update Password</Button>
         </Grid>
       </Grid>


### PR DESCRIPTION
Improved the UI of the Organization's Password Page

## Description
Some Improvements have been done to the Organization's Password Page UI (http://localhost:3000/org/settings/orgName) to make it look better on all screen sizes.

## Related Issue
#503

## Motivation and Context
This will make this page look better on all screen sizes

## How Has This Been Tested?
The video has been attached here:-
https://drive.google.com/file/d/1RkWw-341LJLuSDsmLkN0SHZFNInREWQJ/view?usp=share_link

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/66011090/205274337-88816cf1-a1b3-4a2d-8246-2f7f70f311cd.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
