### PR TITLE
sidebar buttons not appearing fixed

### DIFF
--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -40,7 +40,7 @@ function HomePage({ background = "white", textColor = "black" }) {
   ]);
 
   const windowSize = useWindowSize();
-  const [openMenu, setOpen] = useState(true);
+  const [openMenu, setOpen] = useState(false);
   const toggleSlider = () => {
     setOpen(!openMenu);
   };

--- a/src/components/NavBar/new/MiniNavbar/index.js
+++ b/src/components/NavBar/new/MiniNavbar/index.js
@@ -95,10 +95,10 @@ function MiniNavbar() {
             </Grid>
             <Grid item className={classes.hamburger}>
               <IconButton>
-                {window.innerWidth > 750 && (
+                {window.innerWidth > 960 && (
                   <MenuIcon onClick={() => toggleDrawer(true)} />
                 )}
-                {window.innerWidth <= 750 && (
+                {window.innerWidth <= 960 && (
                   <MenuIcon onClick={() => toggleSlider()} />
                 )}
               </IconButton>
@@ -145,7 +145,7 @@ function MiniNavbar() {
           </Grid>
         </Grid>
       </nav>
-      {windowSize.width > 750 && (
+      {windowSize.width > 960 && (
         <Drawer anchor="right" open={openDrawer} onClose={() => toggleDrawer()}>
           <Grid
             container
@@ -206,13 +206,13 @@ function MiniNavbar() {
           </Grid>
         </Drawer>
       )}
-      {windowSize.width <= 750 && (
+      {windowSize.width <= 960 && (
         <SideBar
           open={openMenu}
           toggleSlider={toggleSlider}
           notification={notification}
         >
-          {window.innerWidth <= 750 && (
+          {window.innerWidth <= 960 && (
             <>
               <Grid
                 item

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -112,7 +112,7 @@ const SideBar = ({
   const classes = useStyles();
   return (
     <>
-      {windowSize.width <= (drawWidth || 750) ? (
+      {windowSize.width <= (drawWidth || 960) ? (
         <Drawer
           closable="true"
           open={open}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have changed the values of breakpoints. So changing them to medium size(960) from small size(750). And set the `openMenu` variable to false, in order to keep it hidden by default and open only when user clicks on hamburger.

## Related Issue
Fixes #538 

## Motivation and Context
Sidebar buttons were not available for all screen sizes, so it is solving this issue.

## How Has This Been Tested?
By using the inspect option, I changed the size of screen and tested it.

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/56391001/208257316-049a8d3e-2bfa-43b2-bdf1-0758f3ac1f59.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
