### PR TITLE
Improved UI for screen size range (960, 1280)

### DIFF
--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -162,7 +162,9 @@ function HomePage({ background = "white", textColor = "black" }) {
       }}
     >
       <Grid className={classes.contentPart}>
-        <div className={classes.sideBody}>
+        <div 
+          className={`${(windowSize.width > 960 && windowSize.width < 1280) && classes.leftSideBody} + ${classes.sideBody}`}
+        >
           {windowSize.width > 750 && (
             <Grid
               item
@@ -201,7 +203,10 @@ function HomePage({ background = "white", textColor = "black" }) {
           })}
         </Grid>
 
-        <Grid item className={classes.sideBody}>
+        <Grid 
+          item 
+          className={`${(windowSize.width > 960 && windowSize.width < 1280) && classes.rightSideBody} + ${classes.sideBody}`}
+        >
           <Grid
             item
             container

--- a/src/components/HomePage/styles.js
+++ b/src/components/HomePage/styles.js
@@ -31,6 +31,14 @@ const useStyles = makeStyles(theme => ({
     },
     maxWidth: "300px"
   },
+  // For making left sidebar small for screen width range (960, 1280) 
+  leftSideBody: {
+    maxWidth: "80px"
+  },
+  // For making right sidebar small for screen width range (960, 1280) 
+  rightSideBody: {
+    maxWidth: "250px"
+  },
   cardBody: {
     display: "flex",
     justifyContent: "space-between",

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -45,7 +45,8 @@ const SideBar = ({
   const firebase = useFirebase();
   const dispatch = useDispatch();
   const allowDashboard = useAllowDashboard();
-
+  const isRenderTitle = windowSize.width >= 1280 || windowSize.width <= 960;
+  
     //Taking out the current organization handle of the user
     const currentOrg = useSelector(
       ({
@@ -131,6 +132,7 @@ const SideBar = ({
             menuItems={menuItems || defaultMenu}
             value={value}
             onStateChange={onStateChange}
+            isRenderTitle={isRenderTitle}
             toggleSlider={toggleSlider}
             style={{
               position: "absolute"
@@ -145,6 +147,7 @@ const SideBar = ({
             menuItems={menuItems || defaultMenu}
             value={value}
             onStateChange={onStateChange}
+            isRenderTitle={isRenderTitle}
             >
               {children}
             </SideList>

--- a/src/components/SideBar/sidelist.js
+++ b/src/components/SideBar/sidelist.js
@@ -61,6 +61,7 @@ const SideList = ({
   menuItems = [],
   value,
   onStateChange = () => {},
+  isRenderTitle,
   toggleSlider = () => {},
   style,
   children
@@ -104,6 +105,7 @@ const SideList = ({
                             />
                           </ListItemIcon>
                         )}
+                        {isRenderTitle && (
                         <ListItemText
                           data-testId={item.name}
                           style={{
@@ -113,7 +115,7 @@ const SideList = ({
                           disableTypography
                         >
                           {item.name}
-                        </ListItemText>
+                        </ListItemText>)}
                     </MenuItem>
                       </NavLink>
                 }
@@ -136,6 +138,7 @@ const SideList = ({
                         />
                       </ListItemIcon>
                     )}
+                    {isRenderTitle && (
                     <ListItemText
                       data-testId={item.name}
                       style={{
@@ -145,7 +148,7 @@ const SideList = ({
                       disableTypography
                     >
                       {item.name}
-                    </ListItemText>
+                    </ListItemText>)}
                   </MenuItem>
                 )}
                 {!item.link && item.onClick && (
@@ -165,7 +168,7 @@ const SideList = ({
                         />
                       </ListItemIcon>
                     )}
-                    <ListItemText
+                    {isRenderTitle && (<ListItemText
                       data-testId={item.name}
                       style={{
                         fontWeight:
@@ -174,7 +177,7 @@ const SideList = ({
                       disableTypography
                     >
                       {item.name}
-                    </ListItemText>
+                    </ListItemText>)}
                   </MenuItem>
                 )}
               </div>


### PR DESCRIPTION
## Description
1. Reduced the width of Left and Right Sidebar for screen size range (960, 1280).
2. Make only icons render in left side bar instead of icon+text. 
3. This will give more space for main content.

## Related Issue
Solves #540 

## Motivation and Context
By doing this changes it will provide more width for main content for this screen size range.

## How Has This Been Tested?
I checked the working of this code by inspecting using inspect feature of Brave browser. I also checked after logging in to see if any problem appear in that case.

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/56391001/208660356-14a0b7e8-866a-4722-a3e1-fd8c92cadf06.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
