### PR TITLE
Added an edit button that appears on organization page if that belongs to current user 

### DIFF
--- a/src/components/Organization/ViewOrganization/index.js
+++ b/src/components/Organization/ViewOrganization/index.js
@@ -215,6 +215,8 @@ const ViewOrganization = () => {
                   CurrentOrg.org_image ? CurrentOrg.org_image : NoImage
                 }
                 story="Think Different"
+                handle={handle}
+                isOrgBelongsToUser = {organizations.includes(handle)}
               />
               <Container
                 maxWidth="xl"

--- a/src/components/ProfileBanner/Organization/index.js
+++ b/src/components/ProfileBanner/Organization/index.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import useStyles from "./styles";
 import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
+import {Link} from "react-router-dom";
 
 import dp from "../../../assets/images/demoperson1.jpeg";
 import iconbuttonImage from "../../../assets/images/unfilled3holes.svg";
@@ -15,7 +16,9 @@ export default function Banner({
   story = "Think Different",
   followers = 402,
   contributors = 402,
-  feed = 40
+  feed = 40,
+  handle = "apple",
+  isOrgBelongsToUser = false,
 }) {
   const classes = useStyles();
   return (
@@ -105,10 +108,17 @@ export default function Banner({
               <Grid
                 item
                 xs={12}
-                md={3}
+                md={isOrgBelongsToUser ? 6 : 3}
                 container
                 className={classes.buttonContainer}
               >
+                {isOrgBelongsToUser && <Link
+                  className={classes.profileEditButton}
+                  data-testId="orgbannereditButton"
+                  to={"/org/settings/"+handle}
+                >
+                  Edit Org
+                </Link>}
                 <IconButton className={classes.moreDiv}>
                   <MoreHorizIcon className={classes.moreButton} />
                 </IconButton>

--- a/src/components/ProfileBanner/Organization/styles.js
+++ b/src/components/ProfileBanner/Organization/styles.js
@@ -1,4 +1,4 @@
-import { red } from "@material-ui/core/colors";
+import { blue, red } from "@material-ui/core/colors";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles(theme => ({
@@ -88,6 +88,22 @@ const useStyles = makeStyles(theme => ({
       background: red[800]
     },
     border: "none"
+  },
+  profileEditButton: {
+    width: "167px",
+    height: "48px",
+    minHeight: "2rem",
+    paddingTop : "8px",
+    background: blue[600],
+    borderRadius: "10px",
+    fontWeight: "500",
+    fontSize: "22px",
+    color: "#FFFFFF",
+    "&:hover": {
+      background: blue[800]
+    },
+    border: "none",
+    marginRight : "30px"
   },
   moreDiv: {
     minHeight: "2rem",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An edit button is added to the organization page that appears only if this organization belongs to currently logged in user. When this button is clicked, the user is redirected to it's settings page.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/scorelab/Codelabz/issues/474

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows user navigate to that organization's page

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Logged in through different users, tested in various window sizes and the edit button was functional.

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/74174769/208859841-9db5fc8b-957c-4c50-a6dc-32a37cd636bc.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
