### PR TITLE
fixed: using display name in new tutorial modal

### DIFF
--- a/src/components/Tutorials/NewTutorial/index.js
+++ b/src/components/Tutorials/NewTutorial/index.js
@@ -175,8 +175,12 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
         <br/>
         
           <div className={classes.root}>
-            <Avatar className={classes.purple}>{sampleName[0]}</Avatar>
-            <Typography className={classes.item}>{sampleName}</Typography>
+          <Avatar className={classes.purple}>
+            {displayName ? displayName[0] : sampleName[0]}
+          </Avatar>
+          <Typography className={classes.item}>
+            {displayName || sampleName}
+          </Typography>
           </div>
             
           <form id="tutorialNewForm">


### PR DESCRIPTION
Using user's display name in new tutorial modal if user is logged in else using sample name

## Motivation and Context
fixes #554 

## Screenshots or GIF (In case of UI changes):
![Screenshot (69)](https://user-images.githubusercontent.com/91831606/209560366-b7b72b45-55b5-4ee9-970f-5add65952b66.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
