### PR TITLE
sidebar-is-open-by-default fixed

### DIFF
--- a/src/components/NavBar/new/MainNavbar/index.js
+++ b/src/components/NavBar/new/MainNavbar/index.js
@@ -26,11 +26,11 @@ const useStyles = makeStyles(theme => ({
   input: {
     marginLeft: theme.spacing(1),
     color: "#3e5060",
-    letterSpacing:"0.5px",
+    letterSpacing: "0.5px",
     flex: 1,
-    width:"92%",
-    [theme.breakpoints.down("md")]:{
-      width:"80%"
+    width: "92%",
+    [theme.breakpoints.down("md")]: {
+      width: "80%"
     }
   },
   root: {
@@ -69,7 +69,7 @@ function MainNavbar() {
   const history = useHistory();
   const windowSize = useWindowSize();
   const [openDrawer, setOpenDrawer] = useState(false);
-  const [openMenu, setOpen] = useState(true);
+  const [openMenu, setOpen] = useState(false);
   const toggleSlider = () => {
     setOpen(!openMenu);
   };
@@ -147,7 +147,7 @@ function MainNavbar() {
             open={openMenu}
             toggleSlider={toggleSlider}
             notification={notification}
-            drawWidth = {960}
+            drawWidth={960}
           />
         )}
       </nav>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
sidebar was open by default

## Description
this issue happened because.
const [openMenu, setOpen] = useState(true); 
the value of openMenu was "true" by default 

before
https://user-images.githubusercontent.com/86488954/210125441-19f15fef-d456-4b48-8bc4-d68b289a8d9c.mp4

PR for  #577 








