### PR TITLE
Extra shadow on activity filter section on profile page removed.

### DIFF
--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -191,7 +191,9 @@ function HomePage({ background = "white", textColor = "black" }) {
         >
           <NewCodelabz setVisibleModal = {setVisibleModal} />
           <NewTutorial viewModal={visibleModal} onSidebarClick={(e) => closeModal(e)} />
-          <Activity />
+          <Card className={classes.card}>
+            <Activity />
+          </Card>
           {userList.persons.map(person => {
             return person.Heading == "CardWithoutPicture" ? (
               <CardWithoutPicture {...person} />

--- a/src/components/HomePage/styles.js
+++ b/src/components/HomePage/styles.js
@@ -6,7 +6,6 @@ const useStyles = makeStyles(theme => ({
     alignItems: "top",
     justifyContent: "center",
     height: "100%",
-
     background: "#f2f2f2"
   },
   mainBody: {
@@ -22,8 +21,7 @@ const useStyles = makeStyles(theme => ({
     alignContent: "center",
     justifyContent: "center",
     width: "100%",
-    marginTop: "1rem",
-    margin: "0 1rem 2rem 1rem",
+    margin: "1rem 1rem 2rem 1rem",
     height: "100%",
     flexDirection: "column",
     [theme.breakpoints.down(960)]: {
@@ -92,6 +90,10 @@ const useStyles = makeStyles(theme => ({
     flexDirection: "row",
     justifyContent: "center",
     maxWidth: "1400px"
+  },
+  card: {
+    padding:"6px",
+    margin:"0 0.5rem 0 0.5rem"
   }
 }));
 

--- a/src/components/Topbar/Activity/index.js
+++ b/src/components/Topbar/Activity/index.js
@@ -15,9 +15,6 @@ const useStyles = makeStyles(theme => ({
     flex: 1,
     padding: "8px",
     alignItems: "center",
-  },
-  card: {
-    margin: "0.5rem"
   }
 }));
 
@@ -45,7 +42,6 @@ function Activity() {
 
   return (
     <React.Fragment>
-      <Card className={classes.card}>
         <Grid container>
           <div className={classes.root}>
             <Grid item>
@@ -62,7 +58,6 @@ function Activity() {
             </Grid>
           </div>
         </Grid>
-      </Card>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The extra shadow that was present on the activity section on the profile page will be removed by this PR.

## Description
1. Removed the card tag from the activity section to fix the shadow on the profile page.
2. Added the card tag for the activity section on the Home Page to eliminate the changes made by the 1st step on the Home Page.

## Related Issue
<!--- Please link to the issue here: --> #588 


## Screenshots or GIF (In case of UI changes):
before
![Screenshot (4)](https://user-images.githubusercontent.com/100015095/210164749-be4bf96c-6e59-47f8-90a2-bd60c8c7a0e6.png) 

After: 
![Screenshot (11)](https://user-images.githubusercontent.com/100015095/210164801-0a2237f4-b642-4c7a-bc1e-94097c764938.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
