### PR TITLE
Changes to show Popular Tags on mobile screens

### DIFF
--- a/src/components/CardTabs/Tags/index.js
+++ b/src/components/CardTabs/Tags/index.js
@@ -14,6 +14,21 @@ const useStyles = makeStyles((theme) => ({
       margin: theme.spacing(0.5),
     },
     marginBottom: "2rem",
+    [theme.breakpoints.down("md")]: {
+      marginBottom: theme.spacing(0),
+      margin: "0.25rem",
+    }
+  },
+  tagsContainer: {
+    [theme.breakpoints.down("sm")]: {
+      maxWidth: "90vw",
+      display: "flex",
+      whiteSpace: "nowrap",
+      overflow: "auto",
+      "&::-webkit-scrollbar": {
+        height: "5px"
+      }
+    }
   },
   chip: {
     margin: "0px 10px 10px 0px",
@@ -30,24 +45,26 @@ const TagCard = (props) => {
       <Card sx={{ minWidth: 275 }}>
         <CardContent>
           <Typography
-            variant="h5"
+            variant="h6"
             component="div"
             gutterBottom
             data-testId="TagsCardTitle"
           >
             Popular Tags
           </Typography>
-          {props.tags.map(function (tag, index) {
-            return (
-              <Chip
-                size="small"
-                label={tag}
-                id={index}
-                className={classes.chip}
-                data-testId={index == 0 ? "TagsChip" : ""}
-              />
-            );
-          })}
+          <div className={classes.tagsContainer}>
+            {props.tags.map(function (tag, index) {
+              return (
+                <Chip
+                  size="small"
+                  label={tag}
+                  id={index}
+                  className={classes.chip}
+                  data-testId={index === 0 ? "TagsChip" : ""}
+                />
+              );
+            })}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -4,6 +4,7 @@ import CardComponent from "../util/CodelabCard/index";
 import Typography from "@material-ui/core/Typography";
 import BottomNavigation from "@material-ui/core/BottomNavigation";
 import BottomNavigationAction from "@material-ui/core/BottomNavigationAction";
+import Box from "@material-ui/core/Box";
 import Grid from "@material-ui/core/Grid";
 import Divider from "@material-ui/core/Divider";
 import ListItem from "@material-ui/core/ListItem";
@@ -192,6 +193,9 @@ function HomePage({ background = "white", textColor = "black" }) {
           <NewCodelabz setVisibleModal = {setVisibleModal} />
           <NewTutorial viewModal={visibleModal} onSidebarClick={(e) => closeModal(e)} />
           <Activity />
+          <Box item sx={{ display: { md: "none" } }}>
+            <TagCard tags={tags} />
+          </Box>
           {userList.persons.map(person => {
             return person.Heading == "CardWithoutPicture" ? (
               <CardWithoutPicture {...person} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made changes to show popular tags in a single row with a horizontal scroll on mobile screens

## Related Issue
Fixes #592 

## How Has This Been Tested?
The changes are made only for viewport width < 960px. 
The UI changes are tested during local development.

## Screenshots or GIF (In case of UI changes):

![image](https://user-images.githubusercontent.com/56475750/210174943-2cfa9c34-d994-4aa9-8db2-6119e7be58b0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
