### PR TITLE
Implemented Tabs based UI  for home page side sections

### DIFF
--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -10,6 +10,14 @@ import Divider from "@material-ui/core/Divider";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import List from "@material-ui/core/List";
+import Tabs from "@material-ui/core/Tabs";
+import Tab from "@material-ui/core/Tab";
+import TabContext from "@material-ui/lab/TabContext";
+import TabPanel from "@material-ui/lab/TabPanel";
+import EventAvailableIcon from "@material-ui/icons/EventAvailable";
+import EventSeatIcon from "@material-ui/icons/EventSeat";
+import SupervisorAccountIcon from "@material-ui/icons/SupervisorAccount";
+import ThumbUpAltIcon from "@material-ui/icons/ThumbUpAlt";
 import { userList } from "./userList";
 import useStyles from "./styles";
 import SideBar from "../SideBar/index";
@@ -27,6 +35,7 @@ import NewTutorial from "../Tutorials/NewTutorial";
 function HomePage({ background = "white", textColor = "black" }) {
   const classes = useStyles();
   const [value, setValue] = useState(2);
+  const [selectedTab, setSelectedTab] = useState("1");
   const [visibleModal, setVisibleModal] = useState(false);
   const [footerContent, setFooterContent] = useState([
     { name: "Help", link: "https://dev.codelabz.io/" },
@@ -150,6 +159,9 @@ function HomePage({ background = "white", textColor = "black" }) {
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
+  const handleTabChange = (event, newValue) => {
+    setSelectedTab(newValue);
+  };
   const closeModal = () => {
     setVisibleModal((prev) => !prev);
   };
@@ -203,6 +215,61 @@ function HomePage({ background = "white", textColor = "black" }) {
               <CardWithPicture {...person} />
             );
           })}
+          <Box
+            sx={{
+              width: "100%",
+              typography: "subtitle1",
+              display: { md: "none" }
+            }}
+          >
+            <TabContext value={selectedTab}>
+              <Tabs
+                value={selectedTab}
+                onChange={handleTabChange}
+                scrollButtons="on"
+                indicatorColor="primary"
+                textColor="primary"
+                aria-label="scrollable force tabs example"
+                style={{
+                  borderBottom: "1px solid gray",
+                  margin: "5px"
+                }}
+              >
+                <Tab
+                  icon={<EventAvailableIcon />}
+                  value="1"
+                  style={{ width: "25%" }}
+                />
+                <Tab
+                  icon={<EventSeatIcon />}
+                  value="2"
+                  style={{ width: "25%" }}
+                />
+                <Tab
+                  icon={<ThumbUpAltIcon />}
+                  value="3"
+                  style={{ width: "25%" }}
+                />
+                <Tab
+                  icon={<SupervisorAccountIcon />}
+                  value="4"
+                  style={{ width: "25%" }}
+                />
+              </Tabs>
+              <TabPanel value="1" style={{ padding: 0 }}>
+                <EventsCard title={"Upcoming Events"} events={upcomingEvents} />
+              </TabPanel>
+              <TabPanel value="2" style={{ padding: 0 }}>
+                <EventsCard title={"Popular Events"} events={upcomingEvents} />
+              </TabPanel>
+              <TabPanel value="3" style={{ padding: 0 }}>
+                <UserCard title={"Who to Follow"} users={usersToFollow} />
+              </TabPanel>
+              <TabPanel value="4" style={{ padding: 0 }}>
+                <UserCard title={"Contributors"} users={contributors} />
+              </TabPanel>
+            </TabContext>
+          </Box>
         </Grid>
 
         <Grid item className={classes.sideBody}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implemented Tabs based UI for small screens to show four side sections present on the right side of the home page on desktop

## Related Issue
Fixes #599 

## How Has This Been Tested?
It's tested to be responsive in UI and functional in all required ways during local development

## Screenshots or GIF (In case of UI changes):

<div style="display:flex;">
  <img src="https://user-images.githubusercontent.com/56475750/210419200-f003609a-4987-495a-918e-06e26e099cc0.png" 
            alt="before" width="300"/>
  <img src="https://user-images.githubusercontent.com/56475750/210419696-be872630-a220-48f0-a97f-46599117085f.png" 
            alt="after" width="300"/>
</div>
<br/>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
