### PR TITLE
Sidebar in home page and in user dashboard fixed.

### DIFF
--- a/src/components/HomePage/styles.js
+++ b/src/components/HomePage/styles.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     alignContent: "center",
     justifyContent: "center",
-    width: "100%",
+    width: "fit-content",
     margin: "1rem 1rem 2rem 1rem",
     height: "100%",
     flexDirection: "column",

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -31,7 +31,7 @@ const useStyles = makeStyles(theme => ({
   },
   card: {
     margin: "0.1rem",
-    padding: "0.5rem"
+    padding: "0.5rem 1.5rem 0.5rem 0.5rem"
   }
 }));
 

--- a/src/components/UserDashboard/index.js
+++ b/src/components/UserDashboard/index.js
@@ -150,7 +150,7 @@ function UserDashboard() {
             />
           </div>
         )}
-        <Grid item xs={6} md={3} className={classes.sidebar}>
+        <Grid item className={classes.sidebar}>
           <SideBar
             open={openMenu}
             toggleSlider={toggleSlider}

--- a/src/components/UserDashboard/styles.js
+++ b/src/components/UserDashboard/styles.js
@@ -54,7 +54,8 @@ const useStyles = makeStyles(theme => ({
   wrapper: {
     display: "flex",
     justifyContent: "center",
-    marginTop: 30
+    marginTop: 30,
+    gap: "1rem"
   },
   sidebar: {
     "@media (max-width: 960px)": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The extra padding in the sidebar in homepage has been removed. Moreover, the overlapping problem in sidebar in user dashboard will also get resolved through this PR.



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce --> #600 
<!--- Please link to the issue here: -->


## How Has This Been Tested?
1. Go to http://localhost:3000/user-dashboard/user-settings
2. Observe that the sidebar does not hide now between screen width of 1000px to 960px.
3. Observe that the extra padding has also been removed from the sidebar in the home page.

## Screenshots or GIF (In case of UI changes):
![Screenshot (15)](https://user-images.githubusercontent.com/100015095/210550727-73bddfa1-faf1-4ca0-b8e3-dcad62234570.png)

![Screenshot (14)](https://user-images.githubusercontent.com/100015095/210550973-5d4e4db9-e52c-4b95-a023-28c9c75094d8.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


