### PR TITLE
Fixed-Last Sidebar Item Should Not Be Empty #624

### DIFF
--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -68,7 +68,8 @@ const SideBar = ({
     },
     {
       name: "Notifications",
-      img: Notification
+      img: Notification,
+      link: "/user-dashboard/notifications"
     },
     {
       name: "User Settings",

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -68,8 +68,7 @@ const SideBar = ({
     },
     {
       name: "Notifications",
-      img: Notification,
-      link: "/user-dashboard/notifications"
+      img: Notification
     },
     {
       name: "User Settings",

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -105,15 +105,27 @@ const SideBar = ({
       img: Tutorials,
       link: "/tutorials"
     },
-    (
-      allowDashboard &&
-      {
-      name: "Logout",
-      img: Logout,
-        onClick: () => signOut()(firebase, dispatch)
-      })
+    // (
+    //  allowDashboard &&
+    //   {
+    //   name: "Logout",
+    //   img: Logout,
+    //   onClick: () => signOut()(firebase, dispatch)
+    //   }) 
   ];
+    
+  // Checks the user handle and sees if user is allowed to access dashboard showing logout option otherwise not..
 
+    if(allowDashboard){
+      defaultMenu.push({
+        name: "Logout",
+        img: Logout,
+        onClick: () => signOut()(firebase, dispatch)
+        })
+
+    }
+    
+   
   const classes = useStyles();
   return (
     <>


### PR DESCRIPTION
Fixed-Last Sidebar Item Should Not Be Empty 

## Description
There is a issue in sidebar  that the last item in the sidebar is an empty button when the user is not logged in. This button should not be present in this case. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Fixes: #624
## Motivation and Context
The change is required because without login there is no meaning to show logout option to the user. This change fulfil the all these requirements.

## How Has This Been Tested?
to check if user is not login I used this code->
if(allowDashboard){
      defaultMenu.push({
        name: "Logout",
        img: Logout,
        onClick: () => signOut()(firebase, dispatch)
        })
    }

to check if user is login I used this code->
if(!allowDashboard){
      defaultMenu.push({
        name: "Logout",
        img: Logout,
        onClick: () => signOut()(firebase, dispatch)
        })
    }
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):
when the user not login--
![userNot](https://user-images.githubusercontent.com/97789487/211182024-5bde2c01-d15e-4af4-9e9f-af996ff3d003.png)

when the user login--
![user](https://user-images.githubusercontent.com/97789487/211182037-70284c8e-c81d-4735-b33f-d9dd4e3a9890.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
