### PR TITLE
Added validation and message for zero organizations in feed

### DIFF
--- a/src/components/MyFeed/Carousel/index.js
+++ b/src/components/MyFeed/Carousel/index.js
@@ -52,27 +52,31 @@ const Carousel = () => {
 
   return (
     <section className={classes.slides}>
-      <ArrowBackIosIcon
-        onClick={prevSlide}
-        data-testId="codefeedLeftarrow"
-        className={classes.arrow}
-        style={{
-          position: "absolute",
-          left: "-2rem",
-          opacity: length === 1 ? 0.2 : 1
-        }}
-      />
-      <ChevronRightIcon
-        onClick={nextSlide}
-        data-testId="codefeedRightarrow"
-        className={classes.arrow}
-        style={{
-          position: "absolute",
-          right: "-2rem",
-          fontSize: "2.3rem",
-          opacity: length === 1 ? 0.2 : 1
-        }}
-      />
+      {launchedOrgs && launchedOrgs.length > 0 && (
+        <>
+          <ArrowBackIosIcon
+            onClick={prevSlide}
+            data-testId="codefeedLeftarrow"
+            className={classes.arrow}
+            style={{
+              position: "absolute",
+              left: "-2rem",
+              opacity: length === 1 ? 0.2 : 1
+            }}
+          />
+          <ChevronRightIcon
+            onClick={nextSlide}
+            data-testId="codefeedRightarrow"
+            className={classes.arrow}
+            style={{
+              position: "absolute",
+              right: "-2rem",
+              fontSize: "2.3rem",
+              opacity: length === 1 ? 0.2 : 1
+            }}
+          />
+        </>
+      )}
 
       {width > 1000 && (
         <div className={classes.slideContainer}>

--- a/src/components/MyFeed/index.js
+++ b/src/components/MyFeed/index.js
@@ -1,3 +1,4 @@
+import { useSelector } from "react-redux";
 import Grid from "@material-ui/core/Grid";
 import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
@@ -11,6 +12,8 @@ const MyFeed = ({
   backgroundcolor = "white",
   textcolor = "black",
 }) => {
+  const launchedOrgs = useSelector(({ org }) => org.launched.data);
+
   return (
     <Box style={{ background: backgroundcolor, color: textcolor }}>
       <Grid container>
@@ -29,6 +32,11 @@ const MyFeed = ({
             {heading}
           </Typography>
           <p>{title}</p>
+          {(!launchedOrgs || !launchedOrgs.length) && (
+            <Typography variant="body1" color="textSecondary" component="p">
+              No Organizations found
+            </Typography>
+          )}
           <div
             style={{
               display: "flex",


### PR DESCRIPTION
## Description
Added a validation to hide carousel icons when there are no organizations on `My Feed` page and instead show a message 'No Organization found'

## Related Issue
Fixes #583 

## How Has This Been Tested?
It's tested during local development

## Screenshots or GIF (In case of UI changes):
![image](https://user-images.githubusercontent.com/56475750/211344070-8fa9bd08-6678-4aaa-b299-e23cb37b0f3d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
