### PR TITLE
fixed Search Icon click bug

### DIFF
--- a/src/components/NavBar/new/MainNavbar/index.js
+++ b/src/components/NavBar/new/MainNavbar/index.js
@@ -116,7 +116,6 @@ function MainNavbar() {
           <Grid item xs={12} md={5}>
             <Paper component={"form"} className={classes.root} elevation={0}>
               <IconButton
-                type="submit"
                 aria-label="search"
                 disableRipple
                 className={classes.icon}

--- a/src/components/NavBar/new/MiniNavbar/index.js
+++ b/src/components/NavBar/new/MiniNavbar/index.js
@@ -139,7 +139,6 @@ function MiniNavbar() {
           <Grid style={{display:'inline-block'}} item xs={12} md={4}>
             <Paper component={"form"} className={classes.root} elevation={0}>
               <IconButton
-                type="submit"
                 aria-label="search"
                 disableRipple
                 className={classes.icon}


### PR DESCRIPTION
Upon clicking the search icon, the page was reloaded because the 'type' property was set to 'submit,' causing the page to be reloaded upon click.

## Description
Removing 'type="submit"' from the search icon resolved the issue.

## Related Issue
fixes #630 

## Motivation and Context
The issue of the page being reloaded upon clicking the search icon should be removed

## How Has This Been Tested?
By clicking the search icon and observing whether the page is reloaded.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
