### PR TITLE
Corrected typo mistakes in rule_sets file

### DIFF
--- a/rule_sets.md
+++ b/rule_sets.md
@@ -1,8 +1,8 @@
 # Important points while using the "test data" file:-
-- You can use the data in the  "testdata" file by importing while starting the emulators,please refer firebase_import_export.md file for indetailed information.
-- if you import the data using "testdata" file the you can see the sample data that contains users,sample tutorials and organisation details.
+- You can use the data in the "testdata" file by importing while starting the emulators, please refer firebase_import_export.md file for indetailed information.
+- If you import the data using "testdata" file the you can see the sample data that contains users, sample tutorials and organisation details.
 - If your using the script for importing and exporting the data, all the changes made in emulators will be reflecting the data associated in the "testdata" file upon exporting it.
-- Don't perform export operation,if no changes are made to the emulators(like adding newuser, creating new orgs and create new codelabz tutorial) this may change the data in the testdata file.
+- Don't perform export operation, if no changes are made to the emulators (like adding newuser, creating new orgs and create new codelabz tutorial) this may change the data in the testdata file.
 - Do not use export operation if you haven't import the data from testdata before
   - you can perform export operation if you have performed import operation while starting the emulators so that the data from testdata file will i.e., remain no change or additional data is appended
 # Export the Emulators data in your own file:-


### PR DESCRIPTION
**Line 2** - Reduce extra space and add space after comma
**Line 3** - Make first letter to capital and add extra space after comma
**Line 5**- Add space before bracket and after comma
