### PR TITLE
fix the issue: last item of sidebar should not be empty

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -44,7 +44,8 @@
     "storage": {
       "port": 9199,
       "host": "127.0.0.1"
-    }
+    },
+    "singleProjectMode": true
   },
   "storage": {
     "rules": "storage.rules"

--- a/functions/auth.js
+++ b/functions/auth.js
@@ -3,7 +3,7 @@ const admin = require("firebase-admin");
 const serviceAccount = require("./private/cl-dev-pk.json");
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: process.env.REACT_APP_DATABASE_URL,
+  databaseURL: "https://codelabz-125-default-rtdb.firebaseio.com",
 });
 
 const db = admin.firestore();

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -105,14 +105,25 @@ const SideBar = ({
       img: Tutorials,
       link: "/tutorials"
     },
-    (
-      allowDashboard &&
-      {
+    // (
+    //   allowDashboard &&
+    //   {
+    //   name: "Logout",
+    //   img: Logout,
+    //     onClick: () => signOut()(firebase, dispatch)
+    //   })
+  ];
+
+  // Checks the user handle and sees if user is allowed to access dashboard showing logout option otherwise not..
+
+  if(allowDashboard){
+    defaultMenu.push({
       name: "Logout",
       img: Logout,
-        onClick: () => signOut()(firebase, dispatch)
+      onClick: () => signOut()(firebase, dispatch)
       })
-  ];
+
+  }
 
   const classes = useStyles();
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is a issue in sidebar that the last item in the sidebar is an empty button when the user is not logged in. This button should not be present in this case.

## Related Issue
Fixes: https://github.com/scorelab/Codelabz/issues/624

## Motivation and Context
The change is required because without login there is no meaning to show logout option to the user. This change fulfil the all these requirements.

## How Has This Been Tested?
to check if user is not login I used this code->
if(allowDashboard){
defaultMenu.push({
name: "Logout",
img: Logout,
onClick: () => signOut()(firebase, dispatch)
})
}

to check if user is login I used this code->
if(!allowDashboard){
defaultMenu.push({
name: "Logout",
img: Logout,
onClick: () => signOut()(firebase, dispatch)
})
}

## Screenshots or GIF (In case of UI changes):

https://user-images.githubusercontent.com/97789487/215093060-26fb776f-9092-4aab-ab1b-34d962e124ae.mp4



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
