### PR TITLE
Fixed unnecessary toggle of sidebar

### DIFF
--- a/src/components/HomePage/index.js
+++ b/src/components/HomePage/index.js
@@ -170,9 +170,6 @@ function HomePage({ background = "white", textColor = "black" }) {
       className={classes.wrapper}
       style={{ background: background }}
       data-testId="homepage"
-      onClick={() => {
-        toggleSlider();
-      }}
     >
       <Grid className={classes.contentPart}>
         <div className={classes.sideBody}>

--- a/src/components/SideBar/sidelist.js
+++ b/src/components/SideBar/sidelist.js
@@ -93,7 +93,7 @@ const SideList = ({
       <MenuList className={classes.menuList}>
         {menuItems.map(function (item, index) {
             return (
-              <div key="menu-items"
+              <div key={item.name}
                style={item.link == location.pathname ?{background:"#d9f1fc",borderRadius:"100px"} :{}}
                >
                 {item.link &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The sidebar was opening unexpectedly on medium screens ( 750px - 960px ) when we click anywhere on the home page.
It was happening because an unnecessary toggle of the sidebar was happening on click to a card component containing all other child components of the home page. I removed that unnecessary toggle.

## Related Issue
Fixes #613 

## How Has This Been Tested?
Its tested to be working during local development. 

## Screenshots or GIF (In case of UI changes):
Find the demo below where the sidebar is opening only when I click hamburger icon and remain closed if I try to click anywhere else.

https://user-images.githubusercontent.com/56475750/215190502-e62b5346-1b2c-46a4-8ea9-b9b6eb031b82.mp4


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
