### PR TITLE
fixed alignment in signin logos

### DIFF
--- a/src/components/AuthPage/smButton/styles.js
+++ b/src/components/AuthPage/smButton/styles.js
@@ -1,41 +1,41 @@
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   button: {
     height: "35px",
     "&:hover": {
-      transform: "scale(1.2)",
-    },
+      transform: "scale(1.2)"
+    }
   },
   root: {
     display: "flex",
     alignItems: "center",
     alignContent: "center",
-    justifyContent: "space-around",
-    flexFlow: "row",
+    justifyContent: "space-evenly",
+    flexFlow: "row"
   },
   fb: {
     fontSize: "42px",
-    color: "#5269a4",
+    color: "#5269a4"
   },
   tw: {
     color: "#7194ef",
-    fontSize: "40px",
+    fontSize: "40px"
   },
   git: {
-    fontSize: "35px",
+    fontSize: "35px"
   },
   go: {},
   imageIcon: {
     display: "flex",
     height: "inherit",
     width: "inherit",
-    margin: "auto",
+    margin: "auto"
   },
   google: {
     textAlign: "center",
-    fontSize: "35px",
-  },
+    fontSize: "35px"
+  }
 }));
 
 export default useStyles;


### PR DESCRIPTION
Fixed alignment of signing logos
<!---  -->

## Description
<!---  -->
fixed space between logos

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#695

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):
<img width="683" alt="Screenshot 2023-02-15 at 12 06 43 AM" src="https://user-images.githubusercontent.com/78907802/218827799-4f17b937-6636-4c9b-9254-9639639489a9.png">



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
