### PR TITLE
Reduce bundle size - react-copy-to-clipboard #782

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "query-string": "^6.13.1",
     "rc-color-picker": "^1.2.6",
     "react": "^18.2.0",
-    "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^18.2.0",
     "react-headroom": "^3.0.0",
     "react-image": "^4.0.3",

--- a/src/components/Tutorials/subComps/ImageDrawer.jsx
+++ b/src/components/Tutorials/subComps/ImageDrawer.jsx
@@ -7,203 +7,215 @@ import { InboxOutlined, LoadingOutlined } from "@ant-design/icons";
 import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch, useSelector } from "react-redux";
 import {
-	clearTutorialImagesReducer,
-	remoteTutorialImages,
-	uploadTutorialImages,
+  clearTutorialImagesReducer,
+  remoteTutorialImages,
+  uploadTutorialImages
 } from "../../../store/actions";
-import { CopyToClipboard } from "react-copy-to-clipboard";
+import PrimarySnackbar from "../../ui-helpers/Snackbars/PrimarySnackbar.jsx";
 
 const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
-	const firebase = useFirebase();
-	const firestore = useFirestore();
-	const dispatch = useDispatch();
+  const firebase = useFirebase();
+  const firestore = useFirestore();
+  const dispatch = useDispatch();
+  const snackbarRef = useRef(null);
 
-	const uploading = useSelector(
-		({
-			tutorials: {
-				images: { uploading },
-			},
-		}) => uploading
-	);
+  const uploading = useSelector(
+    ({
+      tutorials: {
+        images: { uploading }
+      }
+    }) => uploading
+  );
 
-	const uploading_error = useSelector(
-		({
-			tutorials: {
-				images: { uploading_error },
-			},
-		}) => uploading_error
-	);
+  const uploading_error = useSelector(
+    ({
+      tutorials: {
+        images: { uploading_error }
+      }
+    }) => uploading_error
+  );
 
-	const deleting = useSelector(
-		({
-			tutorials: {
-				images: { deleting },
-			},
-		}) => deleting
-	);
+  const deleting = useSelector(
+    ({
+      tutorials: {
+        images: { deleting }
+      }
+    }) => deleting
+  );
 
-	const deleting_error = useSelector(
-		({
-			tutorials: {
-				images: { deleting_error },
-			},
-		}) => deleting_error
-	);
+  const deleting_error = useSelector(
+    ({
+      tutorials: {
+        images: { deleting_error }
+      }
+    }) => deleting_error
+  );
 
-	useEffect(() => {
-		if (uploading === false && uploading_error === false) {
-			<Snackbar
-				anchorOrigin={{
-					vertical: "bottom",
-					horizontal: "left",
-				}}
-				open={true}
-				autoHideDuration={6000}
-				message="Image Uploaded successfully...."
-			/>;
-		} else if (uploading === false && uploading_error) {
-			<Snackbar
-				anchorOrigin={{
-					vertical: "bottom",
-					horizontal: "left",
-				}}
-				open={true}
-				autoHideDuration={6000}
-				message={uploading_error}
-			/>;
-		}
-	}, [uploading, uploading_error]);
+  useEffect(() => {
+    if (uploading === false && uploading_error === false) {
+      <Snackbar
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        open={true}
+        autoHideDuration={6000}
+        message="Image Uploaded successfully...."
+      />;
+    } else if (uploading === false && uploading_error) {
+      <Snackbar
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        open={true}
+        autoHideDuration={6000}
+        message={uploading_error}
+      />;
+    }
+  }, [uploading, uploading_error]);
 
-	useEffect(() => {
-		if (deleting === false && deleting_error === false) {
-			<Snackbar
-				anchorOrigin={{
-					vertical: "bottom",
-					horizontal: "left",
-				}}
-				open={true}
-				autoHideDuration={6000}
-				message="Deleted Succefully...."
-			/>;
-		} else if (deleting === false && deleting_error) {
-			<Snackbar
-				anchorOrigin={{
-					vertical: "bottom",
-					horizontal: "left",
-				}}
-				open={true}
-				autoHideDuration={6000}
-				message={deleting_error}
-			/>;
-		}
-	}, [deleting, deleting_error]);
+  useEffect(() => {
+    if (deleting === false && deleting_error === false) {
+      <Snackbar
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        open={true}
+        autoHideDuration={6000}
+        message="Deleted Succefully...."
+      />;
+    } else if (deleting === false && deleting_error) {
+      <Snackbar
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        open={true}
+        autoHideDuration={6000}
+        message={deleting_error}
+      />;
+    }
+  }, [deleting, deleting_error]);
 
-	useEffect(() => {
-		clearTutorialImagesReducer()(dispatch);
-		return () => {
-			clearTutorialImagesReducer()(dispatch);
-		};
-	}, [dispatch]);
+  useEffect(() => {
+    clearTutorialImagesReducer()(dispatch);
+    return () => {
+      clearTutorialImagesReducer()(dispatch);
+    };
+  }, [dispatch]);
 
-	const props = {
-		name: "file",
-		multiple: true,
-		beforeUpload(file, files) {
-			uploadTutorialImages(owner, tutorial_id, files)(
-				firebase,
-				firestore,
-				dispatch
-			);
-			return false;
-		},
-	};
+  const props = {
+    name: "file",
+    multiple: true,
+    beforeUpload(file, files) {
+      uploadTutorialImages(owner, tutorial_id, files)(
+        firebase,
+        firestore,
+        dispatch
+      );
+      return false;
+    }
+  };
 
-	const deleteFile = (name, url) =>
-		remoteTutorialImages(
-			owner,
-			tutorial_id,
-			name,
-			url
-		)(firebase, firestore, dispatch);
+  const deleteFile = (name, url) =>
+    remoteTutorialImages(
+      owner,
+      tutorial_id,
+      name,
+      url
+    )(firebase, firestore, dispatch);
 
-	return (
-		<Drawer
-			title="Images"
-			data-testid="imageDrawer"
-			anchor="right"
-			closable={true}
-			onClose={onClose}
-			open={visible}
-			getContainer={true}
-			style={{ position: "absolute" }}
-			width="400px"
-			className="image-drawer"
-			destroyOnClose={true}
-			maskClosable={false}>
-			<div className="col-pad-24" data-testId="tutorialImgUpload">
-				<Grid>
-					<input
-						id="file-upload"
-						fullWidth
-						accept="image/*"
-						type="file"
-						{...props}
-					/>
-					{uploading ? (
-						<>
-							<LoadingOutlined /> Please wait...
-							<p className="ant-upload-hint mt-8">Uploading image(s)...</p>
-						</>
-					) : (
-						<>
-							<p className="ant-upload-drag-icon">
-								<InboxOutlined />
-							</p>
-							<p className="ant-upload-text">
-								Click or drag images to here to upload
-							</p>
-						</>
-					)}
-				</Grid>
-				{imageURLs &&
-					imageURLs.length > 0 &&
-					imageURLs.map((image, i) => (
-						<Grid className="mb-24" key={i}>
-							<Grid xs={24} md={8}>
-								<img src={image.url} alt="" />
-							</Grid>
-							<Grid xs={24} md={16} className="pl-8" style={{}}>
-								<h4 className="pb-8">{image.name}</h4>
+  const handleCopyURL = url => {
+    navigator.clipboard.writeText(url).then(() => {
+      snackbarRef.current.openSnackbar();
+    });
+  };
 
-								<CopyToClipboard
-									text={`![alt=image; scale=1.0](${image.url})`}
-									onCopy={() => (
-										<Snackbar
-											anchorOrigin={{
-												vertical: "bottom",
-												horizontal: "left",
-											}}
-											open={true}
-											autoHideDuration={6000}
-											message="Copied...."
-										/>
-									)}>
-									<Button type="primary">Copy URL</Button>
-								</CopyToClipboard>
+  return (
+    <Drawer
+      title="Images"
+      data-testid="imageDrawer"
+      anchor="right"
+      closable={true}
+      onClose={onClose}
+      open={visible}
+      getContainer={true}
+      style={{ position: "absolute" }}
+      width="400px"
+      className="image-drawer"
+      destroyOnClose={true}
+      maskClosable={false}
+    >
+      <div className="col-pad-24" data-testId="tutorialImgUpload">
+        <Grid>
+          <input
+            id="file-upload"
+            fullWidth
+            accept="image/*"
+            type="file"
+            {...props}
+          />
+          {uploading ? (
+            <>
+              <LoadingOutlined /> Please wait...
+              <p className="ant-upload-hint mt-8">Uploading image(s)...</p>
+            </>
+          ) : (
+            <>
+              <p className="ant-upload-drag-icon">
+                <InboxOutlined />
+              </p>
+              <p className="ant-upload-text">
+                Click or drag images to here to upload
+              </p>
+            </>
+          )}
+        </Grid>
+        {imageURLs &&
+          imageURLs.length > 0 &&
+          imageURLs.map((image, i) => (
+            <Grid className="mb-24" key={i}>
+              <Grid xs={24} md={8}>
+                <img src={image.url} alt="" />
+              </Grid>
+              <Grid xs={24} md={16} className="pl-8" style={{}}>
+                <h4 className="pb-8">{image.name}</h4>
+                {/* Copy URL button and Snackbar */}
+                <>
+                  {/* Copy URL to clipboard	button */}
+                  <>
+                    <Button
+                      type="primary"
+                      onClick={() => {
+                        handleCopyURL(`![alt=image; scale=1.0](${image?.url})`);
+                      }}
+                    >
+                      Copy URL
+                    </Button>
+                  </>
 
-								<Button
-									loading={deleting}
-									onClick={() => deleteFile(image.name, image.url)}
-									type="ghost"
-									danger>
-									Delete
-								</Button>
-							</Grid>
-						</Grid>
-					))}
-			</div>
-		</Drawer>
-	);
+                  {/* Snackbar to show on successful copy */}
+                  <>
+                    <PrimarySnackbar ref={snackbarRef} message={"Copied..."} />
+                  </>
+                </>
+
+                <Button
+                  loading={deleting}
+                  onClick={() => deleteFile(image.name, image.url)}
+                  type="ghost"
+                  danger
+                >
+                  Delete
+                </Button>
+              </Grid>
+            </Grid>
+          ))}
+      </div>
+    </Drawer>
+  );
 };
 
 export default ImageDrawer;

--- a/src/components/ui-helpers/Snackbars/PrimarySnackbar.jsx
+++ b/src/components/ui-helpers/Snackbars/PrimarySnackbar.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Snackbar, Alert } from "@mui/material";
+
+const PrimarySnackbar = (props, ref) => {
+  const {
+    message,
+    includeAlert = false,
+    severity = "info",
+    autoHideDuration = 6000,
+    anchorOrigin = {
+      vertical: "bottom",
+      horizontal: "left"
+    }
+  } = props;
+
+  const [open, setOpen] = useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  React.useImperativeHandle(ref, () => ({
+    openSnackbar() {
+      handleClick();
+    }
+  }));
+
+  return (
+    <>
+      <Snackbar
+        anchorOrigin={anchorOrigin}
+        open={open}
+        autoHideDuration={autoHideDuration}
+        onClose={handleClose}
+        message={includeAlert ? "" : message}
+      >
+        {includeAlert ? (
+          <>
+            <Alert handleClose={handleClose} severity={severity}>
+              {message}
+            </Alert>
+          </>
+        ) : null}
+      </Snackbar>
+    </>
+  );
+};
+
+export default React.forwardRef(PrimarySnackbar);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the CopyToClipboard component and the react-copy-to-clipboard dependency. Created my own lighter component to achieve the same functionality.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#782 ](https://github.com/scorelab/Codelabz/issues/782#issue-1651482479)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The functionality of copy-to-clipboard is very limited in our application. So instead of installing a bigger npm library to achieve such a limited use case is more of a overkill. It also helps in reducing the bundle size.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
