### PR TITLE
fixed extra space on menu upon refresh on small screen screen size

### DIFF
--- a/src/App.less
+++ b/src/App.less
@@ -170,6 +170,7 @@ img {
 
 .headroom-wrapper {
 	z-index: 800;
+	height: fit-content!important;
 }
 
 .navbar-mini {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed extra space on menu upon refresh on small screen screen size

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#773

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
upon refresh extra padding was causing the whole initial page to move down making it appear blank, it was a bad ui experience

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally

## Screenshots or GIF (In case of UI changes):
![Recording 2023-04-23 at 23 45 47](https://user-images.githubusercontent.com/98480565/233857555-1399ed93-706f-44ec-a682-e50ed7274edd.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
