### PR TITLE
Fix org setting General tab crash bug

### DIFF
--- a/cypress/e2e/components/auth/logout/logout.cy.js
+++ b/cypress/e2e/components/auth/logout/logout.cy.js
@@ -17,8 +17,10 @@ describe("Testing Logout Functionality | CodeLabz", () => {
 
   it("Logout using Navbar", function () {
     cy.visit(`${this.base_url}`)
+    cy.wait(2000);
     if (cy.get("[data-testid=Logout]").should("not.exist")) {
       cy.get("[data-test-id=login]").click();
+      cy.wait(2000);
       cy.get(".email").type(this.credentials.email);
       cy.get(".password").type(this.credentials.password);
       cy.get("[data-testid=loginButton]").click();
@@ -28,6 +30,7 @@ describe("Testing Logout Functionality | CodeLabz", () => {
       });
     }
     cy.visit(`${this.base_url}`);
+    cy.wait(2000);
     cy.get("[data-testid=Logout]").should("exist");
     cy.get("[data-testid=Logout]").click();
     cy.get("[data-testid=Logout]").should("not.exist");
@@ -41,8 +44,10 @@ describe("Testing Logout Functionality | CodeLabz", () => {
 
   it("Logout using Profile Dropdown", function () {
     cy.visit(`${this.base_url}`)
+    cy.wait(2000);
     if (cy.get("[data-testid=nav-user]").should("not.exist")) {
       cy.get("[data-test-id=login]").click();
+      cy.wait(2000);
       cy.get(".email").type(this.credentials.email);
       cy.get(".password").type(this.credentials.password);
       cy.get("[data-testid=loginButton]").click();
@@ -52,6 +57,7 @@ describe("Testing Logout Functionality | CodeLabz", () => {
       });
     }
     cy.visit(`${this.base_url}`);
+    cy.wait(2000);
     cy.get("[data-testid=nav-user]").should("exist");
     cy.get("[data-testid=nav-user]").click();
     cy.get("#log-out").should("exist");

--- a/src/components/Organization/pages/General.jsx
+++ b/src/components/Organization/pages/General.jsx
@@ -17,7 +17,7 @@ import CardContent from "@mui/material/CardContent";
 import TextField from "@mui/material/TextField";
 import OrgDelete from "../OrgUsers/OrgDelete";
 import { useDispatch, useSelector } from "react-redux";
-import { BasicImage, NoImage } from "../../../helpers/images";
+import { NoImage } from "../../../helpers/images";
 import {
   uploadOrgProfileImage,
   clearEditGeneral,
@@ -329,7 +329,7 @@ function General() {
                         className={classes.ProfilePhotoImage}
                       />
                     ) : (
-                      BasicImage(NoImage, "Not Available")
+                      <img src={NoImage} alt="Not Available" />
                     )}
                   </Grid>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously, when typing on any field in the General tab of the organization settings page, the page would crash on rerender of the component. This issue was caused by the BasicImage component, so I replaced it with img to display the 'NoImage available' image. 

## Related Issue
fixes #793 

## How Has This Been Tested?


https://user-images.githubusercontent.com/91831606/235045758-54a76a87-e772-42c7-983f-151f6c80ed14.mp4




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
