### PR TITLE
change functionality  of "Send me the Link " button 

### DIFF
--- a/src/components/AuthPage/ForgotPassword/index.js
+++ b/src/components/AuthPage/ForgotPassword/index.js
@@ -26,15 +26,25 @@ const ForgotPassword = ({
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const [email, setEmail] = useState("");
+  const [conform, conformemail] = useState(true);
   const [open, setOpen] = React.useState(true);
-  const errorProps = useSelector(({ auth }) => auth.profile.error);
+  const errorProps = useSelector(({ auth }) => {
+  console.log(auth)
+  return auth.profile.error
+});
   const loadingProps = useSelector(({ auth }) => auth.profile.loading);
   const dispatch = useDispatch();
 
   useEffect(() => setError(errorProps), [errorProps]);
   useEffect(() => setLoading(loadingProps), [loadingProps]);
   useEffect(() => setOpen(true), [loadingProps]);
-
+  useEffect(()=>{
+    if(email.includes('@gmail.com') && /[0-9]/.test(email) && /\p{L}/u.test(email)){
+              conformemail(false);
+    } else {
+      conformemail(true);
+    }
+  },[email])
   useEffect(() => {
     if (errorProps === false && loadingProps === false) {
       setSuccess(true);
@@ -68,6 +78,7 @@ const ForgotPassword = ({
     },
   });
   const classes = useStyles();
+ 
 
   return (
     <Card className={classes.root} data-testId="forgotPassword">
@@ -83,6 +94,7 @@ const ForgotPassword = ({
         <br /> we will send you a link to reset your password.
       </p>
 
+        
       {error && (
         <Collapse in={open}>
           <Alert
@@ -117,7 +129,7 @@ const ForgotPassword = ({
         <OutlinedInput
           placeholder="Email"
           autoComplete="email"
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => setEmail(e.target.value)} // email is set to the state .
           className="mb-32"
           fullWidth
           height="10rem"
@@ -133,8 +145,9 @@ const ForgotPassword = ({
           variant="contained"
           color="primary"
           style={{ background: buttonColor }}
-          loading={loading}
+          loading={loading} // state
           className="mt-10"
+          disabled = {conform}
           type="submit"
           fullWidth
           data-testId="forgotPasswordButton"


### PR DESCRIPTION
…ome specific keywords then the button is not going to be disabled



## Description
when user type email , button will only be disabled when user typed correct form of email . email should contain character , number , and @gmail.com other wise button will not be disabled .

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
1. go to forgotpassword page 
2. as you can see that the email can be send even though its wrong format 
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
