### PR TITLE
FIX:Issue# 847 Remove step not working in tutorial creation

### DIFF
--- a/src/components/Tutorials/subComps/RemoveStepModal.jsx
+++ b/src/components/Tutorials/subComps/RemoveStepModal.jsx
@@ -6,7 +6,6 @@ import { useDispatch } from "react-redux";
 import { removeStep } from "../../../store/actions";
 import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
-import Stack from "@mui/material/Stack";
 
 const RemoveStepModal = ({
   owner,

--- a/src/components/Tutorials/subComps/RemoveStepModal.jsx
+++ b/src/components/Tutorials/subComps/RemoveStepModal.jsx
@@ -25,7 +25,7 @@ const RemoveStepModal = ({
     setVisible(viewModal);
   }, [viewModal]);
 
-  const handleOnOk = () => {
+  const handleOnOk = event => {
     <Snackbar
       anchorOrigin={{
         vertical: "bottom",
@@ -36,6 +36,7 @@ const RemoveStepModal = ({
       message="Updating...."
     />;
     if (step_length > 1) {
+      event.preventDefault();
       removeStep(
         owner,
         tutorial_id,
@@ -79,14 +80,14 @@ const RemoveStepModal = ({
     >
       <div>
         <Typography>This action is can not be undone!</Typography>
-        <Stack direction="row" spacing={1}>
+        <form onSubmit={handleOnOk}>
           <Button key="back" onClick={handleOnCancel}>
             <Typography>Cancel</Typography>
           </Button>
-          <Button key="submit" onClick={handleOnOk}>
+          <Button key="remove" type="submit">
             <Typography> Remove</Typography>
           </Button>
-        </Stack>
+        </form>
       </div>
     </Modal>
   );

--- a/src/components/Tutorials/subComps/RemoveStepModal.jsx
+++ b/src/components/Tutorials/subComps/RemoveStepModal.jsx
@@ -6,88 +6,90 @@ import { useDispatch } from "react-redux";
 import { removeStep } from "../../../store/actions";
 import Snackbar from "@mui/material/Snackbar";
 import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
 
 const RemoveStepModal = ({
-	owner,
-	tutorial_id,
-	step_id,
-	viewModal,
-	currentStep,
-	step_length,
+  owner,
+  tutorial_id,
+  step_id,
+  viewModal,
+  currentStep,
+  step_length
 }) => {
-	const firebase = useFirebase();
-	const firestore = useFirestore();
-	const dispatch = useDispatch();
-	const [visible, setVisible] = useState(false);
+  const firebase = useFirebase();
+  const firestore = useFirestore();
+  const dispatch = useDispatch();
+  const [visible, setVisible] = useState(false);
 
-	useEffect(() => {
-		setVisible(viewModal);
-	}, [viewModal]);
+  useEffect(() => {
+    setVisible(viewModal);
+  }, [viewModal]);
 
-	const handleOnOk = () => {
-		<Snackbar
-			anchorOrigin={{
-				vertical: "bottom",
-				horizontal: "left",
-			}}
-			open={true}
-			autoHideDuration={6000}
-			message="Updating...."
-		/>;
-		if (step_length > 1) {
-			removeStep(
-				owner,
-				tutorial_id,
-				step_id,
-				currentStep
-			)(firebase, firestore, dispatch).then(() => {
-				setVisible(false);
-				<Snackbar
-					anchorOrigin={{
-						vertical: "bottom",
-						horizontal: "left",
-					}}
-					open={true}
-					autoHideDuration={6000}
-					message="removed...."
-				/>;
-			});
-		}
-	};
-	const handleOnCancel = () => setVisible(false);
+  const handleOnOk = () => {
+    <Snackbar
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left"
+      }}
+      open={true}
+      autoHideDuration={6000}
+      message="Updating...."
+    />;
+    if (step_length > 1) {
+      removeStep(
+        owner,
+        tutorial_id,
+        step_id,
+        currentStep
+      )(firebase, firestore, dispatch).then(() => {
+        setVisible(false);
+        <Snackbar
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "left"
+          }}
+          open={true}
+          autoHideDuration={6000}
+          message="removed...."
+        />;
+      });
+    }
+  };
+  const handleOnCancel = () => setVisible(false);
 
-	return (
-		<Modal
-			open={visible}
-			onClose={handleOnCancel}
-			aria-labelledby="simple-modal-title"
-			aria-describedby="simple-modal-description"
-			style={{
-				border: "2px solid #000",
-				background: "whitesmoke",
-				boxShadow: "2rem gray",
-				display: "flex",
-				alignItems: "center",
-				justifyContent: "center",
-				height: "10rem",
-				width: "20rem",
-				position: "absolute",
-				top: "40%",
-				left: "40%",
-			}}>
-			<div>
-				<Typography>This action is can not be undone!</Typography>
-				<form onSubmit={handleOnOk}>
-					<Button key="back" onClick={handleOnCancel}>
-						<Typography>Cancel</Typography>
-					</Button>
-					<Button key="submit" type="primary" htmlType="submit">
-						<Typography> Remove</Typography>
-					</Button>
-				</form>
-			</div>
-		</Modal>
-	);
+  return (
+    <Modal
+      open={visible}
+      onClose={handleOnCancel}
+      aria-labelledby="simple-modal-title"
+      aria-describedby="simple-modal-description"
+      style={{
+        border: "2px solid #000",
+        background: "whitesmoke",
+        boxShadow: "2rem gray",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "10rem",
+        width: "20rem",
+        position: "absolute",
+        top: "40%",
+        left: "40%"
+      }}
+    >
+      <div>
+        <Typography>This action is can not be undone!</Typography>
+        <Stack direction="row" spacing={1}>
+          <Button key="back" onClick={handleOnCancel}>
+            <Typography>Cancel</Typography>
+          </Button>
+          <Button key="submit" onClick={handleOnOk}>
+            <Typography> Remove</Typography>
+          </Button>
+        </Stack>
+      </div>
+    </Modal>
+  );
 };
 
 export default RemoveStepModal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes done #847 Remove step not working in tutorial creation
## Description
Fixed the issue in which on clicking the remove button selected tutorial step was not deleting.

## Related Issue
None

## Motivation and Context
This change was required as the tutorial steps were not deleting.
While deleting the selected step the page was reloading due to  implementation of react "form" element, due to which page was reloading and execution was not reaching the remove tutorial steps function.

## How Has This Been Tested?
I have implemented the change and recreate the Issue described on the Issue description.
i exactly followed what has been described in the original Issue and gone through those steps after implementation.

## Screenshots or GIF (In case of UI changes):
Before Fix:
[Buggy issue#847.webm](https://github.com/scorelab/Codelabz/assets/34768582/fa2353b9-85da-4108-a613-aa36a14eb5cb)

After Fix:
[Fix issue#847.webm](https://github.com/scorelab/Codelabz/assets/34768582/8373fd5f-0230-4535-b1d3-a16400e9c89b)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
