### PR TITLE
move to trash fixed

### DIFF
--- a/src/components/Card/CardWithoutPicture.jsx
+++ b/src/components/Card/CardWithoutPicture.jsx
@@ -61,7 +61,10 @@ const useStyles = makeStyles(theme => ({
     padding: "4px"
   },
   settings: {
-    flexWrap: "wrap"
+    flexWrap: "wrap",
+    alignItems:"center",
+    justifyContent:"center"
+
   }
 }));
 

--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -6,11 +6,15 @@ import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import ListIcon from "@mui/icons-material/List";
+import Tooltip from "@mui/material/Tooltip";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ChatIcon from "@mui/icons-material/Chat";
 import EditIcon from "@mui/icons-material/Edit";
+import { useHistory } from "react-router-dom";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import AddIcon from "@mui/icons-material/Add";
+import Modal from "@mui/material/Modal";
+import Typography from "@mui/material/Typography";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
@@ -40,10 +44,13 @@ const EditControls = ({
 }) => {
   const firebase = useFirebase();
   const firestore = useFirestore();
+  const history = useHistory();
   const dispatch = useDispatch();
   const [viewRemoveStepModal, setViewRemoveStepModal] = useState(false);
   const [viewColorPickerModal, setViewColorPickerModal] = useState(false);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const [publishLoad, setPublishLoad] = useState(false);
+  const [deleteConfirmationModal, setDeleteConfirmationModal] = useState(false);
   const DropdownMenu = () => {
     const [anchorEl, setAnchorEl] = React.useState(null);
 
@@ -54,7 +61,48 @@ const EditControls = ({
     const handleClose = () => {
       setAnchorEl(null);
     };
+    const handleDeleteConfirmation = () => {
+      setDeleteConfirmationModal(true);
+    };
+    const handleDeleteConfirm = () => {
+      // Perform deletion logic here, e.g., show a confirmation dialog, and navigate back if confirmed
+      // You can use history.goBack() to go back to the previous page
+      // ...
+      setDeleteConfirmationModal(false);
+      history.goBack(); // Go back to the previous page
+    };
+    const handleDeleteCancel = () => {
+      setDeleteConfirmationModal(false);
+    };
+    const tooltipStyles = `
+    .tooltip-container {
+      position: relative;
+      display: inline-block;
+  
+    }
 
+    .tooltip-container .tooltip-text {
+      visibility: hidden;
+      width: 180px;
+      background-color: #555;
+      color: #fff;
+      text-align: center;
+      border-radius: 6px;
+      padding: 5px 0;
+      position: absolute;
+      z-index: 1;
+      bottom: 125%;
+      left: 50%;
+      margin-left: -60px;
+      opacity: 0;
+      transition: opacity 0.3s;
+    }
+
+    .tooltip-container:hover .tooltip-text {
+      visibility: visible;
+      opacity: 1;
+    }
+  `;
     return (
       <>
         <Button
@@ -92,13 +140,60 @@ const EditControls = ({
           >
             <FormatPaintIcon /> Edit CodeLabz Theme
           </MenuItem>
-          <MenuItem
-            key="delete_tutorial"
-            onClick={() => null}
-            style={{ color: "red" }}
-          >
-            <DeleteIcon /> Move to Trash
-          </MenuItem>
+          <MenuItem key="delete_tutorial" onClick={!isPublished?handleDeleteConfirmation:""} style={{ color: isPublished ? "black" : "red", cursor: isPublished ? "not-allowed" : "pointer" }}>
+  <DeleteIcon />
+  {!isPublished ? (
+  
+    "Move to Trash"
+  ) : (
+    <div>
+      <style>{tooltipStyles}</style>
+      <div className="tooltip-container">
+        Move to Trash
+        <div className="tooltip-text">Unpublish to enable</div>
+      </div>
+    </div>
+  )}
+</MenuItem>
+<Modal
+  open={deleteConfirmationModal}
+  onClose={handleDeleteCancel}
+  aria-labelledby="delete-confirmation-modal-title"
+  aria-describedby="delete-confirmation-modal-description"
+  sx={{
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.9)", // Background color with opacity
+  }}
+>
+  <Box
+    sx={{
+      width: 400,
+      bgcolor: "background.paper",
+      p: 2,
+      textAlign: "center", // Center-align the buttons
+    }}
+  >
+    <Typography id="delete-confirmation-modal-title" variant="h6" component="div">
+      Delete Confirmation
+    </Typography>
+    <Typography id="delete-confirmation-modal-description" sx={{ mt: 2 }}>
+      Are you sure you want to delete this tutorial?
+    </Typography>
+    <Button
+      variant="contained"
+      color="error"
+      onClick={handleDeleteConfirm}
+      sx={{ mt: 2 }} // Add some margin top
+    >
+      Yes
+    </Button>
+    <Button variant="contained" color="primary" onClick={handleDeleteCancel} sx={{ mt: 2, mx:2}}>No</Button>
+  </Box>
+</Modal>
+
+
         </Menu>
       </>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When navigating to the "My Tutorials" page and creating a tutorial, clicking the "Move to Trash" button doesn't behave as expected. This pull request addresses the issue and provides the following changes:
- If the tutorial is already published, the "Move to Trash" button is now disabled and not clickable.
- If the tutorial is unpublished, clicking the "Move to Trash" button triggers a modal dialog to confirm deletion.
- Upon confirming deletion in the modal, the user is redirected to the tutorial homepage or an appropriate page.

## Related Issue
#935 fixed

## Motivation and Context
This change is required to provide users with the expected behavior when dealing with tutorials. It solves the problem of the "Move to Trash" button not working as intended.


## How Has This Been Tested?
I have tested these changes as follows:
- Created a new tutorial and ensured that the "Move to Trash" button is disabled when the tutorial is published.
- Created a new tutorial and confirmed that a modal dialog appears to confirm deletion when the tutorial is unpublished.
- Confirmed that upon confirming deletion, the user is redirected to the appropriate page.

## Screenshots or GIF (In case of UI changes):
https://github.com/scorelab/Codelabz/assets/90304648/b55abe25-ee7f-4eba-a3b4-8d3cbf04ea48
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

