### PR TITLE
Finish button & functionality added

### DIFF
--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -7,6 +7,7 @@ import Button from "@mui/material/Button";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import ListIcon from "@mui/icons-material/List";
 import DeleteIcon from "@mui/icons-material/Delete";
+import DoneIcon from "@mui/icons-material/Done";
 import ChatIcon from "@mui/icons-material/Chat";
 import EditIcon from "@mui/icons-material/Edit";
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -21,7 +22,9 @@ import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch } from "react-redux";
 import RemoveStepModal from "./RemoveStepModal";
 import ColorPickerModal from "./ColorPickerModal";
+import { useHistory } from 'react-router-dom';
 import { Box, Stack } from "@mui/system";
+
 
 const EditControls = ({
   isPublished,
@@ -50,11 +53,11 @@ const EditControls = ({
     const handleClick = event => {
       setAnchorEl(event.currentTarget);
     };
-
+    
     const handleClose = () => {
       setAnchorEl(null);
     };
-
+    
     return (
       <>
         <Button
@@ -113,7 +116,7 @@ const EditControls = ({
     );
     setPublishLoad(false);
   };
-
+  const historyRouter = useHistory();
   return (
     <>
       <Stack
@@ -201,6 +204,9 @@ const EditControls = ({
               >
                 <FileCopyIcon /> {isPublished ? "Unpublish" : "Publish"}
               </Button>
+              <Button disabled={!isPublished} onClick={()=> historyRouter.push("/")}>
+  {isPublished && <DoneIcon />} {isPublished ? "Finish" : ""}
+</Button>
               <DropdownMenu key="more" />
             </>
           )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This feature PR adds a finish button to the tutorial publishing page. When a user publishes their tutorial, the finish button will be enabled and allow them to redirect to the homepage. If the tutorial is unpublished, the finish button will be disabled.
This change was made to improve the user experience by allowing users to easily redirect to the homepage after publishing their tutorial. Previously, there was no way to do this without using the browser's back button.



## Motivation and Context
Users need to be able to easily redirect to the homepage after publishing their tutorial so that they can continue using the application.

## How Has This Been Tested?
Tested it locally

## Screenshots or GIF (In case of UI changes):
Previously, nothing happened after clicking on publish:

https://github.com/scorelab/Codelabz/assets/90304648/b162b9f3-c536-49df-99fc-ec13cdfafb53

Finish button and functionality added:

https://github.com/scorelab/Codelabz/assets/90304648/e54d9093-5321-40a3-b1ff-3a495025270e



## Types of changes



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
