### PR TITLE
Add files via upload

### DIFF
--- a/src/components/AuthPage/Login/index.jsx
+++ b/src/components/AuthPage/Login/index.jsx
@@ -49,7 +49,11 @@ const Login = ({
   const loadingProp = useSelector(({ auth }) => auth.profile.loading);
   const dispatch = useDispatch();
 
-  useEffect(() => setError(errorProp), [errorProp]);
+  useEffect(() => {
+    if (errorProp){
+    setError('Login Cancelled');
+    }
+  }, [errorProp]);
   useEffect(() => setLoading(loadingProp), [loadingProp]);
 
   useEffect(
@@ -129,6 +133,11 @@ const Login = ({
           {loginText}
         </Typography>
         <ViewAlerts error={error} email={email} />
+        {/* {error ? ( 
+          <ViewAlerts error={error} email={email} /> 
+        ):(
+          <ViewAlerts error={''} email={email} /> 
+        )} */}
         <div>
           <TextField
             error={emailValidateError}


### PR DESCRIPTION
**Issue Resolved**
Fixes #915 
**Description**
This pull request addresses the issue where a long error message was displayed when a user canceled the login process initiated through any authentication option. The original error message was:

Firebase: The popup has been closed by the user before finalizing the operation. (auth/popup-closed-by-user)

The proposed solution is to replace this verbose message with a more user-friendly and concise message:

Login cancelled !

This change aims to provide a better user experience by presenting a shorter and clearer message when a user decides to cancel the login process midway.

**Changes Made**
Updated the error message to display "Login cancelled !" when the user cancels the login process.

**Additional Notes**
Tested the changes to ensure they work as intended.
Verified that the new error message provides a more user-friendly experience.

**Video Reference** 

https://github.com/scorelab/Codelabz/assets/112710558/170e78ea-a809-408b-820d-b2b37d83659f

