### PR TITLE
POPUP MODAL on successfully publishing/unpublishing tutorials

### DIFF
--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -216,7 +216,11 @@ const EditControls = ({
         tutorial_id={tutorial_id}
         owner={owner}
       />
-    
+      <SuccessModal
+        visible={showSuccessModal}
+        onClose={() => setShowSuccessModal(false)}
+        message="tutorial published succesfully "
+      />
     </>
   );
 };

--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -106,7 +106,7 @@ const EditControls = ({
     );
   };
   const [showSuccessModal, setShowSuccessModal] = useState(false);
-
+  const [successMessage, setSuccessMessage] = useState("");
   const handlePublishTutorial = async () => {
     setPublishLoad(true);
     await publishUnpublishTutorial(owner, tutorial_id, isPublished)(
@@ -116,6 +116,7 @@ const EditControls = ({
     );
     setPublishLoad(false);
     setShowSuccessModal(true);
+    setSuccessMessage(isPublished ? "Tutorial unpublished successfully!" : "Tutorial published successfully!");
   };
 
   return (
@@ -219,7 +220,7 @@ const EditControls = ({
       <SuccessModal
         visible={showSuccessModal}
         onClose={() => setShowSuccessModal(false)}
-        message="tutorial published succesfully "
+        message={successMessage}
       />
     </>
   );

--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -21,6 +21,7 @@ import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch } from "react-redux";
 import RemoveStepModal from "./RemoveStepModal";
 import ColorPickerModal from "./ColorPickerModal";
+import SuccessModal from "./SuccessModal.jsx";
 import { Box, Stack } from "@mui/system";
 
 const EditControls = ({
@@ -44,6 +45,7 @@ const EditControls = ({
   const [viewRemoveStepModal, setViewRemoveStepModal] = useState(false);
   const [viewColorPickerModal, setViewColorPickerModal] = useState(false);
   const [publishLoad, setPublishLoad] = useState(false);
+
   const DropdownMenu = () => {
     const [anchorEl, setAnchorEl] = React.useState(null);
 
@@ -103,6 +105,8 @@ const EditControls = ({
       </>
     );
   };
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+
   const handlePublishTutorial = async () => {
     setPublishLoad(true);
     await publishUnpublishTutorial(owner, tutorial_id, isPublished)(
@@ -111,6 +115,7 @@ const EditControls = ({
       dispatch
     );
     setPublishLoad(false);
+    setShowSuccessModal(true);
   };
 
   return (
@@ -211,6 +216,7 @@ const EditControls = ({
         tutorial_id={tutorial_id}
         owner={owner}
       />
+    
     </>
   );
 };

--- a/src/components/Tutorials/subComps/SuccessModal.jsx
+++ b/src/components/Tutorials/subComps/SuccessModal.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Modal from "@mui/material/Modal";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+const SuccessModal = ({ visible, onClose, message }) => {
+  return (
+    <Modal open={visible} onClose={onClose}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 300,
+          bgcolor: "background.paper",
+          boxShadow: 24,
+          p: 4,
+        }}
+      >
+        <Typography variant="h6">{message}</Typography>
+      </Box>
+    </Modal>
+  );
+};
+
+export default SuccessModal;

--- a/src/components/Tutorials/subComps/SuccessModal.jsx
+++ b/src/components/Tutorials/subComps/SuccessModal.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import Modal from "@mui/material/Modal";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import Button from "@mui/material/Button";
 
 const SuccessModal = ({ visible, onClose, message }) => {
   return (
@@ -13,12 +15,22 @@ const SuccessModal = ({ visible, onClose, message }) => {
           left: "50%",
           transform: "translate(-50%, -50%)",
           width: 300,
-          bgcolor: "background.paper",
-          boxShadow: 24,
-          p: 4,
+          bgcolor: "white",
+          borderRadius: "8px",
+          boxShadow: "0px 4px 16px rgba(0, 0, 0, 0.1)",
+          padding: "16px",
+          textAlign: "center",
         }}
       >
-        <Typography variant="h6">{message}</Typography>
+        <CheckCircleIcon
+          sx={{ color: "green", fontSize: "48px", marginBottom: "16px" }}
+        />
+        <Typography variant="h6" sx={{ marginBottom: "16px" }}>
+          {message}
+        </Typography>
+        <Button variant="contained" color="primary" onClick={onClose}>
+          Close
+        </Button>
       </Box>
     </Modal>
   );


### PR DESCRIPTION
This pull request adds a success modal component to display according success messages for tutorial publishing and unpublishing.

## Description
Created a SucessModal component for displaying success messages,
Also introduced a successMessage state to dynamically set the message in the success modal based on the action taken.

## Related Issue

#984

## Motivation and Context

To provide users with a visually appealing and informative way to receive feedback on their actions, particularly when publishing or unpublishing tutorials. 


## Screenshots or GIF (In case of UI changes):
[Screencast from 2023-12-24 10-12-02.webm](https://github.com/scorelab/Codelabz/assets/82017158/8dc3f2b2-239f-4b99-9ed6-240fd63784bc)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
