### PR TITLE
[ Fix : Inconsistent step titles (#1025) ]

### DIFF
--- a/src/components/Tutorials/index.jsx
+++ b/src/components/Tutorials/index.jsx
@@ -273,7 +273,7 @@ const ViewTutorial = () => {
                     {mode === "edit" && (
                       <>
                         <StepsTitle
-                          currentStepNo={currentStepNo}
+                          currentStepNo={currentStep}
                           owner={tutorialData.owner}
                           tutorial_id={tutorialData.tutorial_id}
                           step_id={stepsData[currentStep].id}

--- a/src/components/Tutorials/subComps/StepsTitle.jsx
+++ b/src/components/Tutorials/subComps/StepsTitle.jsx
@@ -6,7 +6,7 @@ import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch, useSelector } from "react-redux";
 import { updateStepTime, updateStepTitle } from "../../../store/actions";
 
-const StepsTitle = ({ owner, tutorial_id }) => {
+const StepsTitle = ({ owner, tutorial_id, currentStepNo }) => {
   const firebase = useFirebase();
   const firestore = useFirestore();
   const dispatch = useDispatch();
@@ -36,7 +36,7 @@ const StepsTitle = ({ owner, tutorial_id }) => {
   useEffect(() => {
     if (current_data) {
       const { steps } = current_data;
-      const current_step_data = steps[current_step_no];
+      const current_step_data = steps[currentStepNo];
       set_step_id(current_step_data.id);
       set_step_title(current_step_data.title);
       setNewStepTitle(current_step_data.title);
@@ -50,7 +50,8 @@ const StepsTitle = ({ owner, tutorial_id }) => {
     set_step_id,
     set_step_title,
     set_step_time,
-    current_step_no
+    current_step_no,
+    currentStepNo
   ]);
 
   const setStepTitle = () => {


### PR DESCRIPTION
## Description

This pull request addresses the issue of inconsistent step titles displayed in Editor Mode by ensuring that the currentStepNo is correctly passed and utilized in the StepsTitle component. Previously, the current_step_no was being accessed from redux store which don't seem to be necessary as doing the same in abpve component.

No visual enhancements have been made in this update.

## Related Issue

Fixes #1025 

##Video


https://github.com/scorelab/Codelabz/assets/123815256/1dbb8a5c-3fdc-446b-a45d-fe0e189d0c09



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.