### PR TITLE
Move to trash functionality fixed

### DIFF
--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -6,6 +6,7 @@ import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import ListIcon from "@mui/icons-material/List";
+import { useHistory } from "react-router-dom";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ChatIcon from "@mui/icons-material/Chat";
 import EditIcon from "@mui/icons-material/Edit";
@@ -17,6 +18,7 @@ import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
 import FormatPaintIcon from "@mui/icons-material/FormatPaint";
 import UserList from "../../Editor/UserList";
 import { publishUnpublishTutorial } from "../../../store/actions";
+import { removetut } from "../../../store/actions";
 import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch } from "react-redux";
 import RemoveStepModal from "./RemoveStepModal";
@@ -39,6 +41,7 @@ const EditControls = ({
   step_length
 }) => {
   const firebase = useFirebase();
+  const history = useHistory();
   const firestore = useFirestore();
   const dispatch = useDispatch();
   const [viewRemoveStepModal, setViewRemoveStepModal] = useState(false);
@@ -54,7 +57,43 @@ const EditControls = ({
     const handleClose = () => {
       setAnchorEl(null);
     };
-
+   
+    const handleDeleteTutorial = async () => {
+      await removetut(owner,tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+      history.push("/")
+    };
+    console.log(tutorial_id); 
+    const tooltipStyles = `
+    .tooltip-container {
+      position: relative;
+      display: inline-block;
+  
+    }
+    .tooltip-container .tooltip-text {
+      visibility: hidden;
+      width: 180px;
+      background-color: #555;
+      color: #fff;
+      text-align: center;
+      border-radius: 6px;
+      padding: 5px 0;
+      position: absolute;
+      z-index: 1;
+      bottom: 125%;
+      left: 50%;
+      margin-left: -60px;
+      opacity: 0;
+      transition: opacity 0.3s;
+    }
+    .tooltip-container:hover .tooltip-text {
+      visibility: visible;
+      opacity: 1;
+    }
+  `;
     return (
       <>
         <Button
@@ -92,13 +131,22 @@ const EditControls = ({
           >
             <FormatPaintIcon /> Edit CodeLabz Theme
           </MenuItem>
-          <MenuItem
-            key="delete_tutorial"
-            onClick={() => null}
-            style={{ color: "red" }}
-          >
-            <DeleteIcon /> Move to Trash
-          </MenuItem>
+         
+          <MenuItem key="delete_tutorial" onClick={!isPublished?handleDeleteTutorial:""} style={{ color: isPublished ? "black" : "red", cursor: isPublished ? "not-allowed" : "pointer" }}>
+  <DeleteIcon />
+  {!isPublished ? (
+
+    "Move to Trash"
+  ) : (
+    <div>
+      <style>{tooltipStyles}</style>
+      <div className="tooltip-container">
+        Move to Trash
+        <div className="tooltip-text">Unpublish to enable</div>
+      </div>
+    </div>
+  )}
+</MenuItem>
         </Menu>
       </>
     );

--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -57,16 +57,12 @@ const EditControls = ({
     const handleClose = () => {
       setAnchorEl(null);
     };
-   
+
     const handleDeleteTutorial = async () => {
-      await removetut(owner,tutorial_id)(
-        firebase,
-        firestore,
-        dispatch
-      );
-      history.push("/")
+      await removetut(owner, tutorial_id)(firebase, firestore, dispatch);
+      history.push("/");
     };
-    console.log(tutorial_id); 
+    console.log(tutorial_id);
     const tooltipStyles = `
     .tooltip-container {
       position: relative;
@@ -131,22 +127,28 @@ const EditControls = ({
           >
             <FormatPaintIcon /> Edit CodeLabz Theme
           </MenuItem>
-         
-          <MenuItem key="delete_tutorial" onClick={!isPublished?handleDeleteTutorial:""} style={{ color: isPublished ? "black" : "red", cursor: isPublished ? "not-allowed" : "pointer" }}>
-  <DeleteIcon />
-  {!isPublished ? (
 
-    "Move to Trash"
-  ) : (
-    <div>
-      <style>{tooltipStyles}</style>
-      <div className="tooltip-container">
-        Move to Trash
-        <div className="tooltip-text">Unpublish to enable</div>
-      </div>
-    </div>
-  )}
-</MenuItem>
+          <MenuItem
+            key="delete_tutorial"
+            onClick={!isPublished ? handleDeleteTutorial : ""}
+            style={{
+              color: isPublished ? "black" : "red",
+              cursor: isPublished ? "not-allowed" : "pointer"
+            }}
+          >
+            <DeleteIcon />
+            {!isPublished ? (
+              "Move to Trash"
+            ) : (
+              <div>
+                <style>{tooltipStyles}</style>
+                <div className="tooltip-container">
+                  Move to Trash
+                  <div className="tooltip-text">Unpublish to enable</div>
+                </div>
+              </div>
+            )}
+          </MenuItem>
         </Menu>
       </>
     );

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -57,6 +57,7 @@ export {
   publishUnpublishTutorial,
   remoteTutorialImages,
   removeStep,
+  removetut,
   searchFromTutorialsIndex,
   setCurrentStep,
   setCurrentStepNo,

--- a/src/store/actions/tutorialsActions.js
+++ b/src/store/actions/tutorialsActions.js
@@ -378,6 +378,22 @@ export const removeStep =
       }
     };
 
+    export const removetut =
+    (owner,tutorial_id) =>
+      async (firebase, firestore, dispatch) => {
+        try {
+          await firestore
+            .collection("tutorials")
+            .doc(tutorial_id)
+            .delete()
+             console.log("suraj")
+           
+        } catch (e) {
+          console.log(e.message);
+         
+        }
+      };
+
 export const setCurrentStep = data => async dispatch =>
   dispatch({ type: actions.SET_EDITOR_DATA, payload: data });
 

--- a/src/store/actions/tutorialsActions.js
+++ b/src/store/actions/tutorialsActions.js
@@ -230,36 +230,36 @@ export const getCurrentTutorialData =
 
 export const addNewTutorialStep =
   ({ owner, tutorial_id, title, time, id }) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        dispatch({ type: actions.CREATE_TUTORIAL_STEP_START });
+  async (firebase, firestore, dispatch) => {
+    try {
+      dispatch({ type: actions.CREATE_TUTORIAL_STEP_START });
 
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .collection("steps")
-          .doc(id)
-          .set({
-            content: `Switch to editor mode to begin <b>${title}</b> step`,
-            id,
-            time,
-            title,
-            visibility: true,
-            deleted: false
-          });
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .collection("steps")
+        .doc(id)
+        .set({
+          content: `Switch to editor mode to begin <b>${title}</b> step`,
+          id,
+          time,
+          title,
+          visibility: true,
+          deleted: false
+        });
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
 
-        dispatch({ type: actions.CREATE_TUTORIAL_STEP_SUCCESS });
-      } catch (e) {
-        console.log("CREATE_TUTORIAL_STEP_FAIL", e.message);
-        dispatch({ type: actions.CREATE_TUTORIAL_STEP_FAIL, payload: e.message });
-      }
-    };
+      dispatch({ type: actions.CREATE_TUTORIAL_STEP_SUCCESS });
+    } catch (e) {
+      console.log("CREATE_TUTORIAL_STEP_FAIL", e.message);
+      dispatch({ type: actions.CREATE_TUTORIAL_STEP_FAIL, payload: e.message });
+    }
+  };
 
 export const clearCreateTutorials = () => dispatch =>
   dispatch({ type: actions.CLEAR_CREATE_TUTORIALS_STATE });
@@ -305,94 +305,88 @@ export const setCurrentStepContent =
 
 export const hideUnHideStep =
   (owner, tutorial_id, step_id, visibility) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        /* not being used */
-        // const type = await checkUserOrOrgHandle(owner)(firebase);
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .collection("steps")
-          .doc(step_id)
-          .update({
-            [`visibility`]: !visibility,
-            updatedAt: firestore.FieldValue.serverTimestamp()
-          });
+  async (firebase, firestore, dispatch) => {
+    try {
+      /* not being used */
+      // const type = await checkUserOrOrgHandle(owner)(firebase);
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .collection("steps")
+        .doc(step_id)
+        .update({
+          [`visibility`]: !visibility,
+          updatedAt: firestore.FieldValue.serverTimestamp()
+        });
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
 export const publishUnpublishTutorial =
   (owner, tutorial_id, isPublished) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .update({
-            ["isPublished"]: !isPublished
-          });
+  async (firebase, firestore, dispatch) => {
+    try {
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .update({
+          ["isPublished"]: !isPublished
+        });
 
-        getCurrentTutorialData(owner, tutorial_id)(firebase, firestore, dispatch);
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      getCurrentTutorialData(owner, tutorial_id)(firebase, firestore, dispatch);
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
 export const removeStep =
   (owner, tutorial_id, step_id, current_step_no) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .collection("steps")
-          .doc(step_id)
-          .delete()
+  async (firebase, firestore, dispatch) => {
+    try {
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .collection("steps")
+        .doc(step_id)
+        .delete();
 
-        // const data = await firestore
-        //   .collection("tutorials")
-        //   .doc(tutorial_id)
-        //   .collection("steps")
-        //   .doc(step_id)
-        //   .get();
+      // const data = await firestore
+      //   .collection("tutorials")
+      //   .doc(tutorial_id)
+      //   .collection("steps")
+      //   .doc(step_id)
+      //   .get();
 
-        await setCurrentStepNo(
-          current_step_no > 0 ? current_step_no - 1 : current_step_no
-        )(dispatch);
+      await setCurrentStepNo(
+        current_step_no > 0 ? current_step_no - 1 : current_step_no
+      )(dispatch);
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
-    export const removetut =
-    (owner,tutorial_id) =>
-      async (firebase, firestore, dispatch) => {
-        try {
-          await firestore
-            .collection("tutorials")
-            .doc(tutorial_id)
-            .delete()
-             console.log("suraj")
-           
-        } catch (e) {
-          console.log(e.message);
-         
-        }
-      };
+export const removetut =
+  (owner, tutorial_id) => async (firebase, firestore) => {
+    try {
+      await firestore.collection("tutorials").doc(tutorial_id).delete();
+      console.log("suraj");
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
 export const setCurrentStep = data => async dispatch =>
   dispatch({ type: actions.SET_EDITOR_DATA, payload: data });
@@ -481,69 +475,69 @@ export const remoteTutorialImages =
 
 export const updateStepTitle =
   (owner, tutorial_id, step_id, step_title) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        const dbPath = `tutorials/${tutorial_id}/steps`;
-        await firestore
-          .collection(dbPath)
-          .doc(step_id)
-          .update({
-            [`title`]: step_title,
-            updatedAt: firestore.FieldValue.serverTimestamp()
-          });
-
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e);
-      }
-    };
-
-export const updateStepTime =
-  (owner, tutorial_id, step_id, step_time) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        const dbPath = `tutorials/${tutorial_id}/steps`;
-
-        await firestore
-          .collection(dbPath)
-          .doc(step_id)
-          .update({
-            [`time`]: step_time,
-            updatedAt: firestore.FieldValue.serverTimestamp()
-          });
-
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
-
-export const setTutorialTheme =
-  ({ tutorial_id, owner, bgColor, textColor }) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        const dbPath = `tutorials`;
-
-        await firestore.collection(dbPath).doc(tutorial_id).update({
-          text_color: textColor,
-          background_color: bgColor,
+  async (firebase, firestore, dispatch) => {
+    try {
+      const dbPath = `tutorials/${tutorial_id}/steps`;
+      await firestore
+        .collection(dbPath)
+        .doc(step_id)
+        .update({
+          [`title`]: step_title,
           updatedAt: firestore.FieldValue.serverTimestamp()
         });
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+export const updateStepTime =
+  (owner, tutorial_id, step_id, step_time) =>
+  async (firebase, firestore, dispatch) => {
+    try {
+      const dbPath = `tutorials/${tutorial_id}/steps`;
+
+      await firestore
+        .collection(dbPath)
+        .doc(step_id)
+        .update({
+          [`time`]: step_time,
+          updatedAt: firestore.FieldValue.serverTimestamp()
+        });
+
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
+
+export const setTutorialTheme =
+  ({ tutorial_id, owner, bgColor, textColor }) =>
+  async (firebase, firestore, dispatch) => {
+    try {
+      const dbPath = `tutorials`;
+
+      await firestore.collection(dbPath).doc(tutorial_id).update({
+        text_color: textColor,
+        background_color: bgColor,
+        updatedAt: firestore.FieldValue.serverTimestamp()
+      });
+
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Made necessary changes ensuring that both functionalities now work correctly. Specifically, users cannot delete a tutorial before unpublishing it. After unpublishing, the "Move to Trash" button becomes enabled, and upon clicking it, the tutorial is successfully deleted from the database. Additionally, I removed the extra finish modal as per the feedback.

## Related Issue

Solved #935 

## Motivation and Context

The changes were made to enhance the user experience and ensure that the deletion process follows the expected workflow. By implementing the suggested modifications, the application now aligns with user expectations and provides a smoother interaction.

## Screenshots or GIF (In case of UI changes):

https://github.com/scorelab/Codelabz/assets/90304648/a31c083f-69f4-4617-8036-3e8c253277fc


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
