### PR TITLE
org-page-site-break-fixed

### DIFF
--- a/src/components/Organization/ViewOrganization/index.jsx
+++ b/src/components/Organization/ViewOrganization/index.jsx
@@ -67,7 +67,6 @@ const ViewOrganization = () => {
       }
     }) => (organizations ? organizations[0] : undefined)
   );
-
   const aboutfeedlist = [
     {
       id: 1,
@@ -124,6 +123,10 @@ const ViewOrganization = () => {
       });
   }, [db, profileData.uid]);
 
+  const [currentOrgData,setCurrentOrgData]=useState(CurrentOrg)
+  
+  // console.log({ profileData })
+
   const handleOrgSubscription = async () => {
     if (!currentOrgData.userSubscription)
       await subscribeOrg(handle)(firebase, firestore, dispatch);
@@ -138,14 +141,7 @@ const ViewOrganization = () => {
     }) => loading
   );
 
-  const currentOrgData = useSelector(
-    ({
-      org: {
-        data: { data }
-      }
-    }) => data
-  );
-
+  
   const organizations = useSelector(
     ({
       firebase: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes site breakage when navigating to the organization page.
## Related Issue
Fixes #1036 

## Motivation and Context

The issue caused the site to break when users navigated to an organization page. This fix addresses the problem, ensuring a smooth user experience when accessing organization details.

## How Has This Been Tested?
Tested the fix by following the steps mentioned in the original issue report:
1. Clicked on the user profile icon in the upper-right corner.
2. Selected "My Organization."
3. Chose a specific named organization.
4. Verified that the site no longer breaks and organization details are displayed correctly.


## Screenshots or GIF (In case of UI changes):


https://github.com/scorelab/Codelabz/assets/90304648/d0e07579-1bcd-46e1-af7a-d09111355a1d



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
