### PR TITLE
Org's name still visible even after deletion fixed and Org page not opening issue fixed . Issue #1068 fixed 

### DIFF
--- a/src/components/NavBar/new/MainNavbar/RightMenu.jsx
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useFirebase } from "react-redux-firebase";
 import { signOut } from "../../../../store/actions";
 import Avatar from "@mui/material/Avatar";
@@ -80,8 +80,8 @@ const RightMenu = ({ mode, onClick }) => {
     }) => current
   );
 
-  //Check if this current user is attached to some organization
-  const isOrgPresent = currentOrg == null ? false : true;
+
+ 
 
   const organizations = useSelector(
     ({
@@ -137,7 +137,7 @@ const RightMenu = ({ mode, onClick }) => {
             </ListItem>
           )}
 
-          {allowDashboard && allowOrgs && (
+          {allowDashboard && currentOrg && allowOrgs && (
             <Accordion
               style={{
                 width: "98%"
@@ -149,7 +149,7 @@ const RightMenu = ({ mode, onClick }) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Grid container direction="column" spacing={1}>
-                  {isOrgPresent && (
+                  {currentOrg && (
                     <Grid item>
                       <Link to={`/org/settings/${currentOrg}`}>
                         <Grid container spacing={3}>
@@ -287,7 +287,7 @@ const RightMenu = ({ mode, onClick }) => {
             </Link>
           </MenuItem>
         )}
-        {allowDashboard && allowOrgs && (
+        {allowDashboard && currentOrg &&  allowOrgs && (
           <Accordion>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <BlockOutlinedIcon />
@@ -296,7 +296,7 @@ const RightMenu = ({ mode, onClick }) => {
             <AccordionDetails>
               <Grid container direction="column" spacing={1}>
                 {/* Issue490: We will be connecting organizations to their settings page here*/}
-                {isOrgPresent && (
+                {currentOrg && (
                   <Grid item>
                     <Link to={`/org/settings/${currentOrg}`}>
                       <Grid container spacing={3}>

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -229,7 +229,7 @@ export const getOrgData =
     try {
       dispatch({ type: actions.GET_ORG_DATA_START });
 
-      const isOrgExists = await checkOrgHandleExists(org_handle)(firestore);
+      const isOrgExists = await checkOrgHandleExists(org_handle)(firebase);
 
       if (isOrgExists) {
         const doc = await firestore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Now once the org is deleted the user can't see the org's name in the right menu bar. To achieve this solution I have changes in RightMenu.jsx file . Also I have fixed the org's page not opening issue . Now when the user clicks on the org's name in the right menu the user will be redirected to its org's page . I achieved this just by passing the firebase object instead of firestore in the checkOrgHandleExists function in orgAction.js .

## Related Issue

#1068 fixed 

## Motivation and Context

User wasn't getting redirected to the org's page even after clicking on the org's name in the right menu . Also when the user deletes the org the org's name was still visible in the right menu .

## Test Results 
![image](https://github.com/scorelab/Codelabz/assets/112710558/bec869ee-18a2-478d-b623-371cbdffda5d)


## Screenshots or GIF (In case of UI changes):

https://github.com/scorelab/Codelabz/assets/112710558/ba51d0b2-4bb4-412d-b445-5c1f5219e6e7


## Types of changes

Issue-fixed

## Checklist:

- [✓] My code follows the code style of this project.
- [✗] My change requires a change to the documentation.
- [✓] All new and existing tests passed.

## Request to review
@Sarfraz-droid @Shiva-Nanda @shivareddy6 @Maahi10001 @ABHISHEK-PANDEY2 please review my pull request