### PR TITLE
Implemented add email as backup and primary email functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "redux-thunk": "^2.3.0",
     "simple-peer": "^9.11.1",
     "start-server-and-test": "^1.15.3",
+    "sweetalert2": "^11.10.3",
     "swiper": "^10.2.0",
     "url": "^0.11.0",
     "validator": "^13.6.0",

--- a/src/components/Forms/UserEmail/index.jsx
+++ b/src/components/Forms/UserEmail/index.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import useStyles from "./styles";
-import data from "./emailAddressConfig.json";
+import Swal from 'sweetalert2'
 import {
   Box,
   Card,
@@ -8,26 +8,68 @@ import {
   Typography,
   MenuItem,
   Select,
-  OutlinedInput
+  OutlinedInput,
+  TextField,
+  Button
 } from "@mui/material";
 import { Input } from "../../ui-helpers/Inputs/PrimaryInput";
-import { useSelector } from "react-redux";
+import { useFirebase, useFirestore } from "react-redux-firebase";
+import { useDispatch, useSelector } from "react-redux";
+import { changeUserEmail } from "../../../store/actions";
+import validator from "validator";
 
 const UserEmail = () => {
   const classes = useStyles();
 
-  const [primaryEmail, setPrimaryEmail] = useState(data.primaryEmail);
-  const [backupEmail, setBackupEmail] = useState(data.backupEmail);
+  const firebase = useFirebase();
+  const firestore = useFirestore();
+  const dispatch = useDispatch();
 
+  const [typedEmail, setTypedEmail] = useState('')
+  const [selectedEmailType, setSelectedEmailType] = useState('primary email');
   const profileData = useSelector(({ firebase: { profile } }) => profile);
 
-  const handleChangePrimaryEmail = event => {
-    setPrimaryEmail(event.target.value);
-  };
+  const [primaryEmail, setPrimaryEmail] = useState(profileData.email ? profileData.email : "none")
+  const [backupEmail, setBackupEmail] = useState(profileData.backupEmail ? profileData.backupEmail : "none")
 
-  const handleChangeBackupEmail = event => {
-    setBackupEmail(event.target.value);
-  };
+  const handleChangeEmailType = event => {
+    setSelectedEmailType(event.target.value)
+  }
+
+  const handleEmailChange = async (e) => {
+    e.preventDefault();
+    if (!validator.isEmail(typedEmail)) {
+      Swal.fire({
+        icon: "error",
+        title: "Oops...",
+        text: "Please enter a valid email!",
+      });
+      return
+    } else if (typedEmail == primaryEmail || typedEmail == backupEmail) {
+      Swal.fire({
+        icon: "error",
+        title: "Oops...",
+        text: "You are already using this email!",
+      });
+      return
+    }
+    await changeUserEmail(typedEmail, selectedEmailType, profileData.handle)(firebase, firestore, dispatch)
+
+    if (selectedEmailType == "primary") {
+      setPrimaryEmail(typedEmail)
+    } else {
+      setBackupEmail(typedEmail)
+    }
+    Swal.fire({
+      title: "success!",
+      text: `${selectedEmailType} email added successfully`,
+      icon: "success"
+    });
+
+
+
+
+  }
 
   return (
     <Card className={classes.card}>
@@ -40,7 +82,7 @@ const UserEmail = () => {
         }}
       >
         <Typography style={{ margin: "5px 0" }}>
-          {data.primaryEmail} -{" "}
+          {profileData.email} -{" "}
           <Typography variant="span" style={{ color: "#039500" }}>
             Primary
           </Typography>
@@ -50,12 +92,34 @@ const UserEmail = () => {
           <Box
             style={{ display: "flex", alignItems: "center", margin: "10px 0" }}
           >
-            <Input
-              placeholder="email"
-              className={classes.input}
-              data-testId="emailInput"
-            />
-            <Typography data-testId="addEmail">Add</Typography>
+              <Input
+                placeholder="email"
+                value={typedEmail}
+                onChange={(e) => setTypedEmail(e.target.value)}
+                className={classes.input}
+                data-testId="emailInput"
+                style={{ height: 40, width: 250 }}
+              />
+              <Typography data-testId="addEmail">add as</Typography>
+              <FormControl data-testId="emailType">
+                <Select
+                  value={selectedEmailType}
+                  onChange={handleChangeEmailType}
+                  input={<OutlinedInput style={{ height: 40, width: 250, marginLeft: 5 }} />}
+                  displayEmpty
+                  inputProps={{ "aria-label": "Without label" }}
+                >
+                  <MenuItem value="primary" data-testId="primaryEmailItem">
+                    primary email
+                  </MenuItem>
+                  <MenuItem value="backup" data-testId="backupEmailItem">
+                    backup email
+                  </MenuItem>
+                </Select>
+              </FormControl>
+              <Button type="submit" variant="contained" onClick={handleEmailChange} color="primary" style={{ marginLeft: 5 }}>
+                Add
+              </Button>
           </Box>
         </Box>
         <Box className={classes.email}>
@@ -63,40 +127,31 @@ const UserEmail = () => {
             Primary email address
           </Typography>
           <FormControl data-testId="primaryEmail">
-            <Select
-              value={profileData.email}
-              onChange={handleChangePrimaryEmail}
-              input={<OutlinedInput style={{ height: 40, width: 250 }} />}
-              displayEmpty
-              inputProps={{ "aria-label": "Without label" }}
-            >
-              <MenuItem
-                value={profileData.email}
-                data-testId="primaryEmailItem"
-              >
-                {profileData.email}
-              </MenuItem>
-            </Select>
+            <TextField
+              label="Primary Email"
+              variant="outlined"
+              style={{ height: 40, width: 250, marginBottom: 2 }}
+              value={primaryEmail}
+              // onChange={handleChangePrimaryEmail}
+              InputProps={{ readOnly: true }}
+              inputProps={{ "aria-label": "Primary Email" }}
+            />
           </FormControl>
         </Box>
         <Box className={classes.email}>
           <Typography className={classes.text} style={{ marginRight: 30 }}>
-            Backup email address
+            Backup email   address
           </Typography>
           <FormControl data-testId="backupEmail">
-            <Select
+            <TextField
+              label="Backup Email"
+              variant="outlined"
+              style={{ height: 40, width: 250 }}
               value={backupEmail}
-              onChange={handleChangeBackupEmail}
-              input={<OutlinedInput style={{ height: 40, width: 250 }} />}
-              displayEmpty
-              inputProps={{ "aria-label": "Without label" }}
-            >
-              {data.backupEmailOptions.map(email => (
-                <MenuItem value={email} data-testId="backupEmailItem">
-                  {email}
-                </MenuItem>
-              ))}
-            </Select>
+              // onChange={handleChangeBackupEmail}
+              InputProps={{ readOnly: true }}
+              inputProps={{ "aria-label": "Backup Email" }}
+            />
           </FormControl>
         </Box>
       </Box>

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -41,7 +41,8 @@ export {
   updateUserProfile,
   uploadProfileImage,
   addUserFollower,
-  removeUserFollower
+  removeUserFollower,
+  changeUserEmail
 } from "./profileActions";
 export {
   addNewTutorialStep,


### PR DESCRIPTION
## Description 
Implemented add email as backup and primary email . The user can add an email as it's primary email or backup email .
I have changed the UI a of the email section and used sweetalert library for popups .

## Validation Performed
1.) Mutual exclusivity : User can't add an existing email as backup email or a primary email
2.) Email Validity : User can't enter anything other than an email

## Video Reference 

https://github.com/scorelab/Codelabz/assets/112710558/f4a2e2cc-e969-48cb-9c69-a56a145b3aa2

## Checklist 
[✓] Follows required coding style
[✗] Requires changes in the documentation
[✓] Passes all the tests 

## Request to review 
@ABHISHEK-PANDEY2 @Shiva-Nanda @shivareddy6 @Maahi10001 @Sarfraz-droid  please review my pull request