### PR TITLE
[ Fix : Resolve Unused Prompt Component Bug in QuillEditor ]

### DIFF
--- a/src/components/Editor/QuillEditor.jsx
+++ b/src/components/Editor/QuillEditor.jsx
@@ -52,7 +52,7 @@ const QuillEditor = ({ id, data, tutorial_id }) => {
           var converter = new QuillDeltaToHtmlConverter(deltaText, config);
 
           var html = converter.convert();
-          setCurrentStepContent(tutorial_id, id, html)(firestore, dispatch);
+          setCurrentStepContent(tutorial_id, id, html, setAllSaved)(firestore, dispatch);
         });
         provider = new FirestoreProvider(onlineFirebaseApp, ydoc, basePath, {
           disableAwareness: true
@@ -98,6 +98,10 @@ const QuillEditor = ({ id, data, tutorial_id }) => {
         placeholder: "Start collaborating...",
         theme: "snow"
       });
+
+      editor.on('text-change',function(){
+        setAllSaved(false)
+      })
 
       // provider.awareness.setLocalStateField("user", {
       //   name: currentUserHandle,

--- a/src/store/actions/tutorialsActions.js
+++ b/src/store/actions/tutorialsActions.js
@@ -284,7 +284,7 @@ export const getCurrentStepContentFromFirestore =
   };
 
 export const setCurrentStepContent =
-  (tutorial_id, step_id, content) => async (firestore, dispatch) => {
+  (tutorial_id, step_id, content, setAllSavedCallback) => async (firestore, dispatch) => {
     try {
       const stepDoc = firestore
         .collection("tutorials")
@@ -298,6 +298,9 @@ export const setCurrentStepContent =
       });
 
       dispatch({ type: actions.SET_EDITOR_DATA, payload: content });
+      if (setAllSavedCallback && typeof setAllSavedCallback === 'function') {
+        setAllSavedCallback(true);
+      }
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Resolved the unused Prompt component in QuillEditor, ensuring it now functions as intended when changes are not saved. Using a setAllSavedCallback in setCurrentStepContent, which set's to true after saving it to firestore and dispatch and a text-change event on editor which activates on text change and set allSaved to false each time. Can see it working when the user if offline and creating the tutorial.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1129 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change addresses a bug where the Prompt component in QuillEditor was not being utilized for its intended purpose. By activating the prompt when changes are not saved, we enhance the user experience and maintain consistency in saving data to Firestore.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows OS using Google Chrome.
Created a tutorial in offline mode, added text, and navigated to http://localhost:5173/ to confirm the prompt is activated when changes are not saved.

## Video showing the change :

https://github.com/scorelab/Codelabz/assets/123815256/0bd3b3d3-e014-491f-a614-5cba5da460b0


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
