### PR TITLE
FIXED THE LOWER VALUE OF COUNT UPON CLICKING OF TOGGLE DOWN ARROW BUTTON

### DIFF
--- a/src/components/Card/CardWithPicture.jsx
+++ b/src/components/Card/CardWithPicture.jsx
@@ -83,6 +83,7 @@ export default function CardWithPicture({ tutorial }) {
   };
 
   const handleDecrement = () => {
+    if(count < 1) return;
     setCount(count - 1);
   };
 
@@ -204,7 +205,7 @@ export default function CardWithPicture({ tutorial }) {
             aria-label="left aligned"
           >
             <KeyboardArrowUpIcon />
-            <span>{count}</span>
+            <span>{count>0 ? count : 0 }</span>
           </ToggleButton>
           <ToggleButton
             className={classes.small}

--- a/src/components/Card/CardWithoutPicture.jsx
+++ b/src/components/Card/CardWithoutPicture.jsx
@@ -77,6 +77,7 @@ export default function CardWithoutPicture({ tutorial }) {
   };
 
   const handleDecrement = () => {
+    if(count < 1) return;
     setCount(count - 1);
   };
 
@@ -193,7 +194,7 @@ export default function CardWithoutPicture({ tutorial }) {
             aria-label="left aligned"
           >
             <KeyboardArrowUpIcon />
-            <span>{count}</span>
+            <span>{count>0 ? count : 0 }</span>
           </ToggleButton>
           <ToggleButton
             className={classes.small}

--- a/src/components/TutorialPage/components/Commnets/Comment.jsx
+++ b/src/components/TutorialPage/components/Commnets/Comment.jsx
@@ -89,6 +89,7 @@ const Comment = ({ id }) => {
   };
 
   const handleDecrement = () => {
+    if(count < 1) return;
     setCount(count - 1);
   };
 
@@ -144,7 +145,7 @@ const Comment = ({ id }) => {
                   aria-label="left aligned"
                 >
                   <KeyboardArrowUpIcon />
-                  <span>{count}</span>
+                  <span>{count>0 ? count : 0 }</span>
                 </ToggleButton>
                 <ToggleButton
                   className={classes.small}

--- a/src/components/TutorialPage/components/PostDetails.jsx
+++ b/src/components/TutorialPage/components/PostDetails.jsx
@@ -70,6 +70,7 @@ const PostDetails = ({ details }) => {
   };
 
   const handleDecrement = () => {
+    if(count < 1) return;
     setCount(count - 1);
   };
 
@@ -123,7 +124,7 @@ const PostDetails = ({ details }) => {
                         aria-label="left aligned"
                       >
                         <KeyboardArrowUpIcon />
-                        <span>{count}</span>
+                        <span>{count>0 ? count : 0 }</span>
                       </ToggleButton>
                       <ToggleButton
                         className={classes.small}


### PR DESCRIPTION
## Description

This PR fixes the issue of value going below zero ( i.e negative value) on pressing the toggling down button.
Now the value don't go below zero even if you click on the down button once the value is reached to zero.

<!--- Describe your changes in detail -->
What I did is I first of all make changes in the handleDecrement function which decrease the value of count upon clicking of toggle down arrow button. And then make sure to render the count as it is changing according to the only if the count is greater than zero else in the default case, it's value is zero.

##Related Issue
This PR fixes the issue #953.

## Motivation and Context
A negative value indicating for any thing which can't be negative is not good for user experience

## Screenshots or GIF (In case of UI changes):
[Screencast from 23-01-24 03:06:46 AM IST.webm](https://github.com/scorelab/Codelabz/assets/60067250/90636937-e0f8-4f28-857d-f72225307960)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
