### PR TITLE
Fix initial display on User Settings page

### DIFF
--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -73,7 +73,7 @@ const SideBar = ({
     {
       name: "User Settings",
       img: UserSettings,
-      link: "/user-dashboard/user-settings"
+      link: "/user-dashboard/profile"
     },
     {
       name: "Organization Settings",


### PR DESCRIPTION
issue#1162

Describe the bug
issue Description:
Upon clicking "User Settings" in the sidebar, the expected behavior is for the page to start with the selected profile as indicated in the sidebar. However, the current behavior displays the text "User Settings" instead of the user's profile, which can be confusing and counterintuitive for users.
To Reproduce
Steps to Reproduce:
Navigate to the sidebar.
Click on "User Settings".
Observe the initial display of the page.

Expected behavior
The page should begin by displaying the selected profile, reflecting the user's intention in accessing the settings.
Screenshots
If applicable, add screenshots to help explain your problem.